### PR TITLE
Enabling doc deployments

### DIFF
--- a/.github/workflows/cetlvast.yml
+++ b/.github/workflows/cetlvast.yml
@@ -7,9 +7,19 @@ on:
     branches: [ "main" ]
   release:
     types: [ published ]
+  workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: ghcr.io/opencyphal/toolshed:ts22.4.1
+    steps:
+    - uses: actions/checkout@v3
+    - name: verify
+      run: |
+        ./cetlvast/verify.py -cd ./cetlvast lint
   unittest:
+    needs: lint
     runs-on: ubuntu-latest
     container: ghcr.io/opencyphal/toolshed:ts22.4.1
     strategy:
@@ -18,6 +28,16 @@ jobs:
         toolchain: [gcc, clang]
     steps:
     - uses: actions/checkout@v3
+    - name: setup environment
+      run: echo "CETLVASTS_EXT_PATH=$(./cetlvast/verify.py -cd ./cetlvast -lsext none)" >> $GITHUB_ENV
+    - name: Cache ext modules
+      id: cetlvast-ext
+      uses: actions/cache@v3
+      env:
+        cache-name: cetlvast-ext-cache
+      with:
+        path: ${{ env.CETLVASTS_EXT_PATH }}
+        key: gtest_b796f7d44681514f58a683a3a71ff17c94edb0c1
     - name: verify-gtests
       run: |
         ./cetlvast/verify.py -cd ./cetlvast \
@@ -33,27 +53,50 @@ jobs:
                              --cpp-standard ${{ matrix.std }} \
                              --toolchain ${{ matrix.toolchain }} \
                              compile
-  lint:
-    runs-on: ubuntu-latest
-    container: ghcr.io/opencyphal/toolshed:ts22.4.1
-    steps:
-    - uses: actions/checkout@v3
-    - name: verify
-      run: |
-        ./cetlvast/verify.py -cd ./cetlvast \
-                             lint
+
   docs:
     runs-on: ubuntu-latest
+    needs: unittest
     container: ghcr.io/opencyphal/toolshed:ts22.4.1
     steps:
     - uses: actions/checkout@v3
+    - name: setup environment
+      run: |
+        echo "CETL_DOCS_PATH=$(./cetlvast/verify.py -cd ./cetlvast -lssd docs)" >> $GITHUB_ENV; \
+        echo "CETLVASTS_EXT_PATH=$(./cetlvast/verify.py -cd ./cetlvast -lsext none)" >> $GITHUB_ENV
+    - name: Cache ext modules
+      id: cetlvast-ext
+      uses: actions/cache@v3
+      env:
+        cache-name: cetlvast-ext-cache
+      with:
+        path: ${{ env.CETLVASTS_EXT_PATH }}
+        key: gtest_b796f7d44681514f58a683a3a71ff17c94edb0c1
     - name: verify
       run: ./cetlvast/verify.py -cd ./cetlvast docs
-    - name: upload
-      if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
-      run: |
-        gh-pages \
-          --dotfiles \
-          --message "Doc upload for release ${{ steps.process_event.outputs.tag }}" \
-          --user "${{ env. GITHUB_ACTOR }}" \
-          --dist "$(./cetlvast/verify.py -cd ./cetlvast -lssd docs)/html"
+    - name: Upload docs
+      uses: actions/upload-artifact@v3
+      with:
+        name: github-pages
+        path: "${{ env.CETL_DOCS_PATH }}/html.gz"
+        if-no-files-found: error
+  deploy-docs:
+    if: ${{ (github.event_name == 'release' && !github.event.release.prerelease) || github.event_name == 'workflow_dispatch' }}
+    needs: docs
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/cetlvast/verify.py
+++ b/cetlvast/verify.py
@@ -251,6 +251,21 @@ def _make_parser() -> argparse.ArgumentParser:
     )
 
     action_args.add_argument(
+        "-lsext",
+        "--ls-extdir",
+        action="store_true",
+        help=textwrap.dedent(
+            """
+        Emits a relative path to the external test dependencies directory. Use with "none" suite to
+        simply emit this path and exit. For example:
+
+          - name: setup environment
+            run: echo "CETLVAST_EXT_PATH=$(./cetlvast/verify.py -cd ./cetlvast -lsext none)" >> $GITHUB_ENV
+
+    """[1:])
+    )
+
+    action_args.add_argument(
         "-lssd",
         "--ls-builddir-suite",
         action="store_true",
@@ -695,10 +710,6 @@ def _handle_special_actions(args: argparse.Namespace, cmake_args: typing.List[st
     return 0
 
 
-def _handle_lssd(args: argparse.Namespace, cmake_args: typing.List[str], cmake_dir: pathlib.Path, gitdir: pathlib.Path) -> int:
-    sys.stdout.write(str(cmake_dir / "cetlvast" / "suites" / args.suite))
-    return 0
-
 # +---------------------------------------------------------------------------+
 
 
@@ -738,7 +749,12 @@ def main() -> int:
     )
 
     if args.ls_builddir_suite:
-        return _handle_lssd(args, cmake_args, cmake_dir, verification_dir)
+        sys.stdout.write(str(cmake_dir / "cetlvast" / "suites" / args.suite))
+        return 0
+
+    if args.ls_extdir:
+        sys.stdout.write(str(cmake_dir.parent / pathlib.Path(cmake_dir.stem + "_ext")))
+        return 0
 
     _remove_build_dir_action(args, cmake_dir)
 


### PR DESCRIPTION
Also optimizing the builds to:

1. don't do anything unless lint passes
2. wait to build the docs until the unittests pass
3. allow manual deployment of docs
4. cache the ext folder