### PR TITLE
Fix for #66

### DIFF
--- a/cetlvast/suites/unittest/test_variable_length_array_compat.cpp
+++ b/cetlvast/suites/unittest/test_variable_length_array_compat.cpp
@@ -618,3 +618,59 @@ TYPED_TEST(VLATestsCompatAnyType, TestInitFromString)
     ASSERT_EQ('s', subject[0]);
     ASSERT_EQ('.', subject[subject.size() - 1]);
 }
+
+TYPED_TEST(VLATestsCompatAnyType, TestMakeReverseIterator)
+{
+    std::allocator<bool> allocator{};
+    using SubjectType = typename TestFixture::template TestSubjectType<bool, std::allocator<bool>>;
+    SubjectType subject{allocator};
+    subject.assign(0, true);
+    subject.assign(1, false);
+    subject.assign(2, false);
+    auto rbegin = std::make_reverse_iterator(subject.end());
+    auto rend = std::make_reverse_iterator(subject.begin());
+    auto c = 0;
+    for(auto i = rbegin; i < rend; ++i)
+    {
+        if (c == 0)
+        {
+            ASSERT_FALSE(*i);
+        }
+        else if (c == 1)
+        {
+            ASSERT_FALSE(*i);
+        }
+        else {
+            ASSERT_TRUE(*i);
+        }
+        ++c;
+    }
+}
+
+TYPED_TEST(VLATestsCompatAnyType, TestMakeReverseConstIterator)
+{
+    std::allocator<bool> allocator{};
+    using SubjectType = typename TestFixture::template TestSubjectType<bool, std::allocator<bool>>;
+    SubjectType subject{allocator};
+    subject.assign(0, true);
+    subject.assign(1, false);
+    subject.assign(2, false);
+    auto rbegin = std::make_reverse_iterator(subject.cend());
+    auto rend = std::make_reverse_iterator(subject.cbegin());
+    auto c = 0;
+    for(auto i = rbegin; i < rend; ++i)
+    {
+        if (c == 0)
+        {
+            ASSERT_FALSE(*i);
+        }
+        else if (c == 1)
+        {
+            ASSERT_FALSE(*i);
+        }
+        else {
+            ASSERT_TRUE(*i);
+        }
+        ++c;
+    }
+}

--- a/cetlvast/suites/unittest/test_variable_length_array_compat.cpp
+++ b/cetlvast/suites/unittest/test_variable_length_array_compat.cpp
@@ -624,9 +624,9 @@ TYPED_TEST(VLATestsCompatAnyType, TestMakeReverseIterator)
     std::allocator<bool> allocator{};
     using SubjectType = typename TestFixture::template TestSubjectType<bool, std::allocator<bool>>;
     SubjectType subject{allocator};
-    subject.assign(0, true);
-    subject.assign(1, false);
-    subject.assign(2, false);
+    subject.push_back(true);
+    subject.push_back(false);
+    subject.push_back(false);
     auto rbegin = std::make_reverse_iterator(subject.end());
     auto rend = std::make_reverse_iterator(subject.begin());
     auto c = 0;
@@ -652,9 +652,9 @@ TYPED_TEST(VLATestsCompatAnyType, TestMakeReverseConstIterator)
     std::allocator<bool> allocator{};
     using SubjectType = typename TestFixture::template TestSubjectType<bool, std::allocator<bool>>;
     SubjectType subject{allocator};
-    subject.assign(0, true);
-    subject.assign(1, false);
-    subject.assign(2, false);
+    subject.push_back(true);
+    subject.push_back(false);
+    subject.push_back(false);
     auto rbegin = std::make_reverse_iterator(subject.cend());
     auto rend = std::make_reverse_iterator(subject.cbegin());
     auto c = 0;

--- a/include/cetl/variable_length_array.hpp
+++ b/include/cetl/variable_length_array.hpp
@@ -1645,7 +1645,6 @@ public:
         {
             return !((*this) == rhs);
         }
-
         void flip()
         {
             set(array_, index_, !test(array_, index_));
@@ -1674,9 +1673,9 @@ private:
         using iterator_category = std::random_access_iterator_tag;
         using value_type        = typename A::value_type;
         using difference_type   = typename A::difference_type;
-        using reference         = typename A::reference;
-        using const_reference   = typename A::const_reference;
-        using pointer           = void;
+        using reference =
+            std::conditional_t<std::is_const<A>::value, typename A::const_reference, typename A::reference>;
+        using pointer = void;
 
         IteratorImpl() noexcept = default;
 
@@ -1734,7 +1733,7 @@ private:
         {
             return this->operator[](0);
         }
-        const_reference operator*() const
+        reference operator*() const
         {
             return this->operator[](0);
         }
@@ -1747,7 +1746,7 @@ private:
         {
             return array_->operator[](static_cast<size_type>(static_cast<difference_type>(index_) + n));
         }
-        const_reference operator[](const difference_type n) const
+        reference operator[](const difference_type n) const
         {
             return array_->operator[](static_cast<size_type>(static_cast<difference_type>(index_) + n));
         }


### PR DESCRIPTION
STL iterator expects reference type to be const based on if it is a const iterator or not.