### PR TITLE
Fix issues with bool VariableLengthArray (issues 74 and 75)

### DIFF
--- a/build-tools/bin/verify.py
+++ b/build-tools/bin/verify.py
@@ -692,6 +692,8 @@ def _cmake_configure(args: argparse.Namespace, cmake_args: typing.List[str]) -> 
         cmake_configure_args.append("-DLIBCXX_ENABLE_ASSERTIONS:BOOL=ON")
 
     # --[EXCEPTIONS]---------------------------------------
+    if args.exceptions:
+        cmake_configure_args.append("-DCETLVAST_DISABLE_CPP_EXCEPTIONS:BOOL=OFF")
     if args.no_exceptions:
         cmake_configure_args.append("-DCETLVAST_DISABLE_CPP_EXCEPTIONS:BOOL=ON")
 

--- a/cetlvast/suites/unittest/test_variable_length_array_bool.cpp
+++ b/cetlvast/suites/unittest/test_variable_length_array_bool.cpp
@@ -55,17 +55,31 @@ protected:
     }
 };
 
+template <typename T>
+class VLABoolTestsVLAOnly : public ::testing::Test
+{
+protected:
+    void TearDown() override
+    {
+        T::reset();
+    }
+};
+
 // clang-format off
 namespace cetlvast
 {
-using MyTypes = ::testing::Types<
+using VLAAndVectorTypes = ::testing::Types<
       TypeParamDef<cetlvast::PolymorphicAllocatorNewDeleteFactory, cetl::VariableLengthArray, unsigned char>
     , TypeParamDef<cetlvast::DefaultAllocatorFactory, std::vector, unsigned char>
+>;
+using VLATypes = ::testing::Types<
+      TypeParamDef<cetlvast::PolymorphicAllocatorNewDeleteFactory, cetl::VariableLengthArray, unsigned char>
 >;
 }  // namespace cetlvast
 // clang-format on
 
-TYPED_TEST_SUITE(VLABoolTests, cetlvast::MyTypes, );
+TYPED_TEST_SUITE(VLABoolTests, cetlvast::VLAAndVectorTypes, );
+TYPED_TEST_SUITE(VLABoolTestsVLAOnly, cetlvast::VLATypes, );
 
 // +---------------------------------------------------------------------------+
 // | TEST CASES :: Copy Construction
@@ -363,4 +377,30 @@ TYPED_TEST(VLABoolTests, TestAssignCountAndValue)
     {
         ASSERT_TRUE(*i);
     }
+}
+
+TYPED_TEST(VLABoolTestsVLAOnly, ConstructFromIteratorRange)
+{
+    // Provide it too much stuff
+    std::vector<bool> data{false, true, false};
+    auto subject = TypeParam::make_bool_container(data.begin(), data.end(), 2U);
+    // Should only add to max
+    EXPECT_EQ(subject.size(), 2);
+    EXPECT_EQ(subject[0], false);
+    EXPECT_EQ(subject[1], true);
+}
+
+TYPED_TEST(VLABoolTestsVLAOnly, ExceedMaxSizeMaxFails)
+{
+    std::size_t max = 3U;
+    auto subject = TypeParam::make_bool_container(max);
+    // Try to add one too many
+    for (std::size_t i = 0; i < max + 1; i++) {
+        subject.push_back(true);
+    }
+    // Shouldn't have been added
+    EXPECT_EQ(subject.size(), 3);
+    EXPECT_EQ(subject[0], true);
+    EXPECT_EQ(subject[1], true);
+    EXPECT_EQ(subject[2], true);
 }

--- a/cetlvast/suites/unittest/test_variable_length_array_bool.cpp
+++ b/cetlvast/suites/unittest/test_variable_length_array_bool.cpp
@@ -383,24 +383,38 @@ TYPED_TEST(VLABoolTestsVLAOnly, ConstructFromIteratorRange)
 {
     // Provide it too much stuff
     std::vector<bool> data{false, true, false};
+
+#if defined(__cpp_exceptions)
+    EXPECT_THROW((void)TypeParam::make_bool_container(data.begin(), data.end(), 2U), std::length_error);
+#elif (__cplusplus == CETL_CPP_STANDARD_14)
     auto subject = TypeParam::make_bool_container(data.begin(), data.end(), 2U);
     // Should only add to max
     EXPECT_EQ(subject.size(), 2);
     EXPECT_EQ(subject[0], false);
     EXPECT_EQ(subject[1], true);
+#else
+    GTEST_SKIP() << "C++17 pmr does not support defined out of memory behaviour without exceptions.";
+#endif
 }
 
 TYPED_TEST(VLABoolTestsVLAOnly, ExceedMaxSizeMaxFails)
 {
     std::size_t max = 3U;
     auto subject = TypeParam::make_bool_container(max);
-    // Try to add one too many
-    for (std::size_t i = 0; i < max + 1; i++) {
+    for (std::size_t i = 0; i < max; i++) {
         subject.push_back(true);
     }
+#if defined(__cpp_exceptions)
+    EXPECT_THROW((void)subject.push_back(true), std::length_error);
+#elif (__cplusplus == CETL_CPP_STANDARD_14)
+    // Try to add one too many
+    subject.push_back(true);
     // Shouldn't have been added
     EXPECT_EQ(subject.size(), 3);
     EXPECT_EQ(subject[0], true);
     EXPECT_EQ(subject[1], true);
     EXPECT_EQ(subject[2], true);
+#else
+    GTEST_SKIP() << "C++17 pmr does not support defined out of memory behaviour without exceptions.";
+#endif
 }

--- a/cetlvast/suites/unittest/test_variable_length_array_compat.cpp
+++ b/cetlvast/suites/unittest/test_variable_length_array_compat.cpp
@@ -46,7 +46,7 @@ TYPED_TEST(VLATestsCompatPrimitiveTypes, TestMoveToVector)
     cetl::VariableLengthArray<TypeParam, cetl::pf17::pmr::polymorphic_allocator<TypeParam>>
         subject{10u, cetl::pf17::pmr::polymorphic_allocator<TypeParam>(cetl::pf17::pmr::new_delete_resource())};
     subject.reserve(subject.max_size());
-    ASSERT_EQ(subject.capacity(), subject.max_size());
+    ASSERT_GE(subject.capacity(), subject.max_size());
     for (std::size_t i = 0; i < subject.max_size(); ++i)
     {
         subject.push_back(static_cast<TypeParam>(i % 2));


### PR DESCRIPTION
Fix iterator range constructor signatures to be consistent with type T constructors.
Consistently treat size and max size in terms of number of bits.