### PR TITLE
Fix for #97: "invalid escape sequence \|" warning

### DIFF
--- a/build-tools/bin/verify.py
+++ b/build-tools/bin/verify.py
@@ -161,7 +161,7 @@ class QualifiedAction:
 def _make_parser() -> argparse.ArgumentParser:
 
     prolog =  textwrap.dedent(
-        """
+        r"""
                                           _           _
    ___  _ __   ___ _ __   ___ _   _ _ __ | |__   __ _| |
   / _ \| '_ \ / _ | '_ \ / __| | | | '_ \| '_ \ / _` | |


### PR DESCRIPTION
Making "opencyphal" text logo as a **raw** (unescaped) python string.