### PR TITLE
Almost finalize main api of `cetl::any` - now close to `std::any` features.

### DIFF
--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -185,7 +185,7 @@ TEST(test_any, ctor_6_in_place_initializer_list)
         std::size_t size_;
         int         number_;
 
-        TestType(std::initializer_list<char> const chars, int const number)
+        TestType(const std::initializer_list<char> chars, const int number)
         {
             size_   = chars.size();
             number_ = number;
@@ -309,7 +309,7 @@ TEST(test_any, make_any_2_ilist)
         std::size_t size_;
         int         number_;
 
-        TestType(std::initializer_list<char> const chars, int const number)
+        TestType(const std::initializer_list<char> chars, const int number)
         {
             size_   = chars.size();
             number_ = number;
@@ -332,19 +332,7 @@ TEST(test_any, any_cast_cppref_example)
 
 #if defined(__cpp_exceptions)
 
-    try
-    {
-        (void) any_cast<std::string>(uut{});  // throws!
-        FAIL() << "Should have thrown an exception.";
-
-    } catch (const cetl::bad_any_cast& e)
-    {
-        SUCCEED() << "`bad_any_cast` has been caught.";
-
-    } catch (...)
-    {
-        FAIL() << "Should have thrown `bad_any_cast`.";
-    }
+    EXPECT_THROW(any_cast<std::string>(uut{}), cetl::bad_any_cast);
 
 #endif
 
@@ -355,7 +343,7 @@ TEST(test_any, any_cast_cppref_example)
     EXPECT_STREQ("hollo", any_cast<const std::string&>(a1).c_str());  //< const reference
 
     auto s1 = any_cast<std::string&&>(std::move(a1));  //< rvalue reference
-    // Note: “s1” is a move-constructed std::string, “a1” is empty
+    // Note: `s1` is a move-constructed std::string, `a1` is empty
     static_assert(std::is_same<decltype(s1), std::string>::value, "");
     EXPECT_STREQ("hollo", s1.c_str());
 }
@@ -365,20 +353,10 @@ TEST(test_any, any_cast_1_const)
     using uut = any<sizeof(int)>;
 
 #if defined(__cpp_exceptions)
-    try
-    {
-        const uut empty{};
-        (void) any_cast<int>(empty);  // throws!
-        FAIL() << "Should have thrown an exception.";
 
-    } catch (const cetl::bad_any_cast&)
-    {
-        SUCCEED() << "`bad_any_cast` has been caught.";
+    const uut empty{};
+    EXPECT_THROW(any_cast<std::string>(empty), cetl::bad_any_cast);
 
-    } catch (...)
-    {
-        FAIL() << "Should have thrown `bad_any_cast`.";
-    }
 #endif
 
     const uut src{42};
@@ -394,20 +372,8 @@ TEST(test_any, any_cast_2_non_const)
 
 #if defined(__cpp_exceptions)
 
-    try
-    {
-        uut empty{};
-        (void) any_cast<int>(empty);  // throws!
-        FAIL() << "Should have thrown an exception.";
-
-    } catch (const cetl::bad_any_cast&)
-    {
-        SUCCEED() << "`bad_any_cast` has been caught.";
-
-    } catch (...)
-    {
-        FAIL() << "Should have thrown `bad_any_cast`.";
-    }
+    uut empty{};
+    EXPECT_THROW(any_cast<std::string>(empty), cetl::bad_any_cast);
 
 #endif
 
@@ -438,22 +404,8 @@ TEST(test_any, any_cast_3_move_empty_bad_cast)
 
     using uut = any<sizeof(int)>;
 
-    try
-    {
-        (void) any_cast<int>(uut{});  // throws!
-        FAIL() << "Should have thrown an exception.";
+    EXPECT_THROW(any_cast<std::string>(uut{}), cetl::bad_any_cast);
 
-    } catch (const cetl::bad_any_cast&)
-    {
-        SUCCEED() << "`bad_any_cast` has been caught.";
-
-    } catch (...)
-    {
-        FAIL() << "Should have thrown `bad_any_cast`.";
-    }
-
-#else
-    GTEST_SKIP() << "Not applicable when exceptions are disabled.";
 #endif
 }
 
@@ -556,7 +508,7 @@ TEST(test_any, emplace_2_initializer_list)
         std::size_t size_;
         int         number_;
 
-        TestType(std::initializer_list<char> const chars, int const number)
+        TestType(const std::initializer_list<char> chars, const int number)
         {
             size_   = chars.size();
             number_ = number;

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -509,6 +509,11 @@ TEST(test_any, swap)
     empty.swap(a);
     EXPECT_FALSE(empty.has_value());
     EXPECT_EQ('B', *any_cast<char>(&a));
+
+    uut another_empty{};
+    empty.swap(another_empty);
+    EXPECT_FALSE(empty.has_value());
+    EXPECT_FALSE(another_empty.has_value());
 }
 
 TEST(test_any, emplace_1)

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -27,8 +27,8 @@ TEST(test_any, cppref_example)
 {
     using uut = any<sizeof(int)>;
 
-    uut        a{1};
-    const auto ptr = any_cast<int>(&a);
+    uut        src{1};
+    const auto ptr = any_cast<int>(&src);
     EXPECT_TRUE(ptr);
     EXPECT_EQ(1, *ptr);
 
@@ -156,7 +156,7 @@ TEST(test_any, ctor_4_move_value)
     EXPECT_EQ(1, *any_cast<int>(&dst));
 }
 
-TEST(test_any, ctor_5)
+TEST(test_any, ctor_5_in_place)
 {
     struct TestType
     {
@@ -175,6 +175,28 @@ TEST(test_any, ctor_5)
 
     const auto ptr = any_cast<TestType>(&src);
     EXPECT_EQ('Y', ptr->ch_);
+    EXPECT_EQ(42, ptr->number_);
+}
+
+TEST(test_any, ctor_6_in_place_initializer_list)
+{
+    struct TestType
+    {
+        std::size_t size_;
+        int         number_;
+
+        TestType(std::initializer_list<char> const chars, int const number)
+        {
+            size_   = chars.size();
+            number_ = number;
+        }
+    };
+    using uut = any<sizeof(TestType)>;
+
+    const uut src{in_place_type_t<TestType>{}, {'A', 'B', 'C'}, 42};
+
+    const auto ptr = any_cast<TestType>(&src);
+    EXPECT_EQ(3, ptr->size_);
     EXPECT_EQ(42, ptr->number_);
 }
 
@@ -244,7 +266,7 @@ TEST(test_any, assign_3_move_value)
     }
 }
 
-TEST(test_any, make_any_1_cppref_example)
+TEST(test_any, make_any_cppref_example)
 {
     using uut = any<std::max(sizeof(std::string), sizeof(std::complex<double>))>;
 
@@ -262,8 +284,8 @@ TEST(test_any, make_any_1_cppref_example)
     const any_lambda a2 = [] { return "Lambda #1.\n"; };
     EXPECT_TRUE(a2.has_value());
     // TODO: Uncomment when RTTI will be available.
-    // auto function_ptr = any_cast<lambda>(&a2);
-    // EXPECT_FALSE(function_ptr);
+    // auto function2_ptr = any_cast<lambda>(&a2);
+    // EXPECT_FALSE(function2_ptr);
 
     auto a3 = cetl::make_any<lambda, any_lambda>([] { return "Lambda #2.\n"; });
     EXPECT_TRUE(a3.has_value());
@@ -272,13 +294,176 @@ TEST(test_any, make_any_1_cppref_example)
     EXPECT_STREQ("Lambda #2.\n", (*function3_ptr)());
 }
 
+TEST(test_any, make_any_1)
+{
+    using uut = const any<sizeof(int)>;
+
+    const auto test = cetl::make_any<int, uut>(42);
+    EXPECT_EQ(42, *any_cast<int>(&test));
+}
+
+TEST(test_any, make_any_2_ilist)
+{
+    struct TestType
+    {
+        std::size_t size_;
+        int         number_;
+
+        TestType(std::initializer_list<char> const chars, int const number)
+        {
+            size_   = chars.size();
+            number_ = number;
+        }
+    };
+    using uut = any<sizeof(TestType)>;
+
+    const auto src      = cetl::make_any<TestType, uut>({'A', 'C'}, 42);
+    const auto test_ptr = any_cast<TestType>(&src);
+    EXPECT_EQ(2, test_ptr->size_);
+    EXPECT_EQ(42, test_ptr->number_);
+}
+
+TEST(test_any, any_cast_cppref_example)
+{
+    using uut = any<std::max(sizeof(int), sizeof(std::string))>;
+
+    auto a1 = uut{12};
+    EXPECT_EQ(12, any_cast<int>(a1));
+
+#if defined(__cpp_exceptions)
+
+    try
+    {
+        (void) any_cast<std::string>(uut{});  // throws!
+        FAIL() << "Should have thrown an exception.";
+
+    } catch (const cetl::bad_any_cast& e)
+    {
+        SUCCEED() << "`bad_any_cast` has been caught.";
+
+    } catch (...)
+    {
+        FAIL() << "Should have thrown `bad_any_cast`.";
+    }
+
+#endif
+
+    // Advanced example
+    a1       = std::string("hello");
+    auto& ra = any_cast<std::string&>(a1);  //< reference
+    ra[1]    = 'o';
+    EXPECT_STREQ("hollo", any_cast<const std::string&>(a1).c_str());  //< const reference
+
+    auto s1 = any_cast<std::string&&>(std::move(a1));  //< rvalue reference
+    // Note: “s1” is a move-constructed std::string, “a1” is empty
+    static_assert(std::is_same<decltype(s1), std::string>::value, "");
+    EXPECT_STREQ("hollo", s1.c_str());
+}
+
+TEST(test_any, any_cast_1_const)
+{
+    using uut = any<sizeof(int)>;
+
+#if defined(__cpp_exceptions)
+    try
+    {
+        const uut empty{};
+        (void) any_cast<int>(empty);  // throws!
+        FAIL() << "Should have thrown an exception.";
+
+    } catch (const cetl::bad_any_cast&)
+    {
+        SUCCEED() << "`bad_any_cast` has been caught.";
+
+    } catch (...)
+    {
+        FAIL() << "Should have thrown `bad_any_cast`.";
+    }
+#endif
+
+    const uut src{42};
+    EXPECT_EQ(42, any_cast<int>(src));
+    // EXPECT_EQ(42, any_cast<int&>(src)); //< won't compile expectedly
+    EXPECT_EQ(42, any_cast<const int>(src));
+    EXPECT_EQ(42, any_cast<const int&>(src));
+}
+
+TEST(test_any, any_cast_2_non_const)
+{
+    using uut = any<sizeof(int)>;
+
+#if defined(__cpp_exceptions)
+
+    try
+    {
+        uut empty{};
+        (void) any_cast<int>(empty);  // throws!
+        FAIL() << "Should have thrown an exception.";
+
+    } catch (const cetl::bad_any_cast&)
+    {
+        SUCCEED() << "`bad_any_cast` has been caught.";
+
+    } catch (...)
+    {
+        FAIL() << "Should have thrown `bad_any_cast`.";
+    }
+
+#endif
+
+    uut src{42};
+    EXPECT_EQ(42, any_cast<int>(src));
+    EXPECT_EQ(42, any_cast<int&>(src));
+    EXPECT_EQ(42, any_cast<const int>(src));
+    EXPECT_EQ(42, any_cast<const int&>(src));
+}
+
+TEST(test_any, any_cast_3_move_primitive_int)
+{
+    using uut = any<sizeof(int)>;
+
+    uut src{147};
+    EXPECT_EQ(147, any_cast<int>(std::move(src)));
+    EXPECT_TRUE(src.has_value());  //< expectedly still contains the value - moved from.
+
+    EXPECT_EQ(42, any_cast<int>(uut{42}));
+    // EXPECT_EQ(42, any_cast<int&>(uut{42})); //< won't compile expectedly
+    EXPECT_EQ(42, any_cast<const int>(uut{42}));
+    EXPECT_EQ(42, any_cast<const int&>(uut{42}));
+}
+
+TEST(test_any, any_cast_3_move_empty_bad_cast)
+{
+#if defined(__cpp_exceptions)
+
+    using uut = any<sizeof(int)>;
+
+    try
+    {
+        (void) any_cast<int>(uut{});  // throws!
+        FAIL() << "Should have thrown an exception.";
+
+    } catch (const cetl::bad_any_cast&)
+    {
+        SUCCEED() << "`bad_any_cast` has been caught.";
+
+    } catch (...)
+    {
+        FAIL() << "Should have thrown `bad_any_cast`.";
+    }
+
+#else
+    GTEST_SKIP() << "Not applicable when exceptions are disabled.";
+#endif
+}
+
 TEST(test_any, any_cast_4_const_ptr)
 {
     using uut = const any<sizeof(int)>;
 
-    uut a{147};
+    uut src{147};
 
-    auto int_ptr = any_cast<int>(&a);
+    auto int_ptr = any_cast<int>(&src);
     static_assert(std::is_same<const int*, decltype(int_ptr)>::value, "");
 
     EXPECT_TRUE(int_ptr);
@@ -291,14 +476,95 @@ TEST(test_any, any_cast_5_non_const_ptr)
 {
     using uut = any<sizeof(char)>;
 
-    uut a{'Y'};
+    uut src{'Y'};
 
-    auto char_ptr = any_cast<char>(&a);
+    auto char_ptr = any_cast<char>(&src);
     static_assert(std::is_same<char*, decltype(char_ptr)>::value, "");
     EXPECT_TRUE(char_ptr);
     EXPECT_EQ('Y', *char_ptr);
 
     EXPECT_FALSE((any_cast<char, uut>(nullptr)));
+}
+
+TEST(test_any, swap)
+{
+    using uut = any<sizeof(char)>;
+
+    uut empty{};
+    uut a{'A'};
+    uut b{'B'};
+
+    // Self swap
+    a.swap(a);
+    EXPECT_EQ('A', *any_cast<char>(&a));
+
+    a.swap(b);
+    EXPECT_EQ('B', *any_cast<char>(&a));
+    EXPECT_EQ('A', *any_cast<char>(&b));
+
+    empty.swap(a);
+    EXPECT_FALSE(a.has_value());
+    EXPECT_EQ('B', *any_cast<char>(&empty));
+
+    empty.swap(a);
+    EXPECT_FALSE(empty.has_value());
+    EXPECT_EQ('B', *any_cast<char>(&a));
+}
+
+TEST(test_any, emplace_1)
+{
+    // Primitive `char`
+    {
+        using uut = any<sizeof(char)>;
+
+        uut src;
+        src.emplace<char>('Y');
+        EXPECT_EQ('Y', *any_cast<char>(&src));
+    }
+
+    // `TestType` with two params ctor.
+    {
+        struct TestType
+        {
+            char ch_;
+            int  number_;
+
+            TestType(char ch, int number)
+            {
+                ch_     = ch;
+                number_ = number;
+            }
+        };
+        using uut = any<sizeof(TestType)>;
+
+        uut t;
+        t.emplace<TestType>('Y', 147);
+        EXPECT_EQ('Y', any_cast<TestType>(&t)->ch_);
+        EXPECT_EQ(147, any_cast<TestType>(&t)->number_);
+    }
+}
+
+TEST(test_any, emplace_2_initializer_list)
+{
+    struct TestType
+    {
+        std::size_t size_;
+        int         number_;
+
+        TestType(std::initializer_list<char> const chars, int const number)
+        {
+            size_   = chars.size();
+            number_ = number;
+        }
+    };
+    using uut = any<sizeof(TestType)>;
+
+    uut src;
+    src.emplace<TestType>({'A', 'B', 'C'}, 42);
+
+    const auto test_ptr = any_cast<TestType>(&src);
+    EXPECT_EQ(3, test_ptr->size_);
+    EXPECT_EQ(42, test_ptr->number_);
 }
 
 }  // namespace

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -222,7 +222,7 @@ public:
 
 private:
     // Type-erased handler.
-    using any_handler = void* (*) (detail::action, const any* /*self*/, any* /*other*/);
+    using any_handler = void* (*) (detail::action, const any*, any*);
 
     // Small Object Optimization (SOO) handler.
     template <typename Tp>
@@ -338,7 +338,7 @@ CETL_NODISCARD Any make_any(std::initializer_list<Up> list, Args&&... args)
 template <typename ValueType, typename Any>
 ValueType any_cast(const Any& operand)
 {
-    using RawValueType = typename std::remove_cv<typename std::remove_reference<ValueType>::type>::type;
+    using RawValueType = std::remove_cv_t<std::remove_reference_t<ValueType>>;
     static_assert(std::is_constructible<ValueType, const RawValueType&>::value,
                   "ValueType is required to be a const lvalue reference "
                   "or a CopyConstructible type");
@@ -360,7 +360,7 @@ ValueType any_cast(const Any& operand)
 template <typename ValueType, typename Any>
 ValueType any_cast(Any& operand)
 {
-    using RawValueType = typename std::remove_cv<typename std::remove_reference<ValueType>::type>::type;
+    using RawValueType = std::remove_cv_t<std::remove_reference_t<ValueType>>;
     static_assert(std::is_constructible<ValueType, RawValueType&>::value,
                   "ValueType is required to be an lvalue reference "
                   "or a CopyConstructible type");
@@ -382,7 +382,7 @@ ValueType any_cast(Any& operand)
 template <typename ValueType, typename Any>
 ValueType any_cast(Any&& operand)
 {
-    using RawValueType = typename std::remove_cv<typename std::remove_reference<ValueType>::type>::type;
+    using RawValueType = std::remove_cv_t<std::remove_reference_t<ValueType>>;
     static_assert(std::is_constructible<ValueType, RawValueType>::value,
                   "ValueType is required to be an rvalue reference "
                   "or a CopyConstructible type");

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -13,6 +13,7 @@
 #include "pf17/attribute.hpp"
 
 #include <algorithm>
+#include <initializer_list>
 
 namespace cetl
 {
@@ -88,6 +89,15 @@ enum class action
     Destroy
 };
 
+[[noreturn]] inline void throw_bad_any_cast()
+{
+#if defined(__cpp_exceptions)
+    throw bad_any_cast();
+#else
+    std::terminate();
+#endif
+}
+
 }  // namespace detail
 
 template <std::size_t Footprint, bool Copyable = true, bool Movable = Copyable>
@@ -127,7 +137,11 @@ public:
         soo_handler<Tp>::create(*this, std::forward<Args>(args)...);
     }
 
-    // TODO: Add ctor#6 with `std::initializer_list`.
+    template <typename ValueType, typename Up, typename... Args, typename Tp = std::decay_t<ValueType>>
+    explicit any(in_place_type_t<ValueType>, std::initializer_list<Up> list, Args&&... args)
+    {
+        soo_handler<Tp>::create(*this, list, std::forward<Args>(args)...);
+    }
 
     ~any()
     {
@@ -162,7 +176,12 @@ public:
         return soo_handler<Tp>::create(*this, std::forward<Args>(args)...);
     }
 
-    // TODO: Add emplace#2 with `std::initializer_list`.
+    template <typename ValueType, typename Up, typename... Args, typename Tp = std::decay_t<ValueType>>
+    Tp& emplace(std::initializer_list<Up> list, Args&&... args)
+    {
+        reset();
+        return soo_handler<Tp>::create(*this, list, std::forward<Args>(args)...);
+    }
 
     void reset() noexcept
     {
@@ -176,16 +195,19 @@ public:
             return;
         }
 
-        if (has_value() && rhs.has_value())
+        if (has_value())
         {
-            any tmp;
-            rhs.handle(detail::action::Move, &tmp);
-            handle(detail::action::Move, &rhs);
-            tmp.handle(detail::action::Move, this);
-        }
-        else if (has_value())
-        {
-            handle(detail::action::Move, &rhs);
+            if (rhs.has_value())
+            {
+                any tmp;
+                rhs.handle(detail::action::Move, &tmp);
+                handle(detail::action::Move, &rhs);
+                tmp.handle(detail::action::Move, this);
+            }
+            else
+            {
+                handle(detail::action::Move, &rhs);
+            }
         }
         else if (rhs.has_value())
         {
@@ -208,7 +230,7 @@ private:
     {
         static_assert(sizeof(Tp) <= Footprint, "Enlarge the footprint");
 
-        static void* handle(detail::action action, const any* self, any* other)
+        static void* handle(const detail::action action, const any* const self, any* const other)
         {
             switch (action)
             {
@@ -278,7 +300,7 @@ private:
     template <typename ValueType, typename Any>
     friend std::add_pointer_t<ValueType> any_cast(Any* operand) noexcept;
 
-    void* handle(detail::action action, any* other = nullptr) const
+    void* handle(const detail::action action, any* const other = nullptr) const
     {
         return handler_ ? handler_(action, this, other) : nullptr;
     }
@@ -294,10 +316,84 @@ private:
 template <typename ValueType, typename Any, typename... Args>
 CETL_NODISCARD Any make_any(Args&&... args)
 {
-    return Any(cetl::in_place_type<ValueType>, std::forward<Args>(args)...);
+    return Any(in_place_type<ValueType>, std::forward<Args>(args)...);
 }
 
-// TODO: Add `any_cast` 1, 2 & 3.
+/// \brief Constructs an any object containing an object of type T, passing the provided arguments to T's constructor.
+///
+/// Equivalent to `cetl::any(cetl::in_place_type<ValueType>, list, std::forward<Args>(args)...)`.
+///
+template <typename ValueType, typename Any, typename Up, typename... Args>
+CETL_NODISCARD Any make_any(std::initializer_list<Up> list, Args&&... args)
+{
+    return Any(in_place_type<ValueType>, list, std::forward<Args>(args)...);
+}
+
+/// \brief Performs type-safe access to the contained object.
+///
+/// \param operand Target any object.
+/// \return Returns `std::static_cast<ValueType>(*cetl::any_cast<const U>(&operand))`,
+///     where let `U` be `std::remove_cv_t<std::remove_reference_t<ValueType>>`.
+///
+template <typename ValueType, typename Any>
+ValueType any_cast(const Any& operand)
+{
+    using RawValueType = typename std::remove_cv<typename std::remove_reference<ValueType>::type>::type;
+    static_assert(std::is_constructible<ValueType, const RawValueType&>::value,
+                  "ValueType is required to be a const lvalue reference "
+                  "or a CopyConstructible type");
+
+    auto ptr = any_cast<std::add_const_t<RawValueType>>(&operand);
+    if (ptr == nullptr)
+    {
+        detail::throw_bad_any_cast();
+    }
+    return static_cast<ValueType>(*ptr);
+}
+
+/// \brief Performs type-safe access to the contained object.
+///
+/// \param operand Target any object.
+/// \return Returns `std::static_cast<ValueType>(*cetl::any_cast<U>(&operand))`,
+///     where let `U` be `std::remove_cv_t<std::remove_reference_t<ValueType>>`.
+///
+template <typename ValueType, typename Any>
+ValueType any_cast(Any& operand)
+{
+    using RawValueType = typename std::remove_cv<typename std::remove_reference<ValueType>::type>::type;
+    static_assert(std::is_constructible<ValueType, RawValueType&>::value,
+                  "ValueType is required to be an lvalue reference "
+                  "or a CopyConstructible type");
+
+    auto ptr = any_cast<RawValueType>(&operand);
+    if (ptr == nullptr)
+    {
+        detail::throw_bad_any_cast();
+    }
+    return static_cast<ValueType>(*ptr);
+}
+
+/// \brief Performs type-safe access to the contained object.
+///
+/// \param operand Target any object.
+/// \return Returns `std::static_cast<ValueType>(std::move(*cetl::any_cast<U>(&operand)))`,
+///     where let `U` be `std::remove_cv_t<std::remove_reference_t<ValueType>>`.
+///
+template <typename ValueType, typename Any>
+ValueType any_cast(Any&& operand)
+{
+    using RawValueType = typename std::remove_cv<typename std::remove_reference<ValueType>::type>::type;
+    static_assert(std::is_constructible<ValueType, RawValueType>::value,
+                  "ValueType is required to be an rvalue reference "
+                  "or a CopyConstructible type");
+
+    auto ptr = any_cast<RawValueType>(&operand);
+    if (ptr == nullptr)
+    {
+        detail::throw_bad_any_cast();
+    }
+    return static_cast<ValueType>(std::move(*ptr));
+}
 
 /// \brief Performs type-safe access to the `const` contained object.
 ///
@@ -309,7 +405,7 @@ CETL_NODISCARD Any make_any(Args&&... args)
 ///     a pointer to the value contained by operand, otherwise a null pointer.
 ///
 template <typename ValueType, typename Any>
-CETL_NODISCARD std::add_pointer_t<std::add_const_t<ValueType>> any_cast(const Any* operand) noexcept
+CETL_NODISCARD std::add_pointer_t<std::add_const_t<ValueType>> any_cast(const Any* const operand) noexcept
 {
     return any_cast<ValueType>(const_cast<Any*>(operand));
 }
@@ -324,7 +420,7 @@ CETL_NODISCARD std::add_pointer_t<std::add_const_t<ValueType>> any_cast(const An
 ///     a pointer to the value contained by operand, otherwise a null pointer.
 ///
 template <typename ValueType, typename Any>
-CETL_NODISCARD std::add_pointer_t<ValueType> any_cast(Any* operand) noexcept
+CETL_NODISCARD std::add_pointer_t<ValueType> any_cast(Any* const operand) noexcept
 {
     static_assert(!std::is_reference<ValueType>::value, "`ValueType` may not be a reference.");
 

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -12,6 +12,7 @@
 #include "pf17/utility.hpp"
 #include "pf17/attribute.hpp"
 
+#include <cassert>
 #include <algorithm>
 #include <initializer_list>
 
@@ -262,6 +263,8 @@ private:
         template <typename... Args>
         static Tp& create(any& dest, Args&&... args)
         {
+            assert(nullptr == dest.handler_);
+
             Tp* ret = static_cast<Tp*>(static_cast<void*>(&dest.buffer_));
             new (ret) Tp(std::forward<Args>(args)...);
             dest.handler_ = handle;
@@ -290,6 +293,8 @@ private:
 
         static void destroy(any& self)
         {
+            assert(nullptr != self.handler_);
+
             Tp* ptr = static_cast<Tp*>(static_cast<void*>(&self.buffer_));
             ptr->~Tp();
             self.handler_ = nullptr;


### PR DESCRIPTION
- Added "value return" overloads of any_cast (#1️⃣, 2️⃣ & 3️⃣).
- Added std::initializer_list overloads for
  - ctor (#6️⃣)
  - `emplace` (#2️⃣)
  - `make_any` (#2️⃣)
- Added corresponding unit tests, plus more cases to increase coverage.

Notes for to be continued...
- `Align` param fixes will be in the next pr.
- Copyable/Movable (as well as elimination of various `const_cast`) will be in the after next pr.



