### PR TITLE
Pass `Align` template param; unit test it.

### DIFF
--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -105,15 +105,15 @@ TEST(test_any, cppref_example)
 TEST(test_any, ctor_1_default)
 {
     EXPECT_FALSE((any<0>{}.has_value()));
-    EXPECT_EQ(sizeof(std::max_align_t), alignof(any<0>));
+    EXPECT_EQ(alignof(std::max_align_t), alignof(any<0>));
     EXPECT_FALSE((any<0, false>{}.has_value()));
     EXPECT_FALSE((any<0, false, true>{}.has_value()));
     EXPECT_FALSE((any<0, true, false>{}.has_value()));
     EXPECT_FALSE((any<0, true, true, 0>{}.has_value()));
-    EXPECT_EQ(sizeof(std::max_align_t), alignof(any<0, true, true, 0>));
+    EXPECT_EQ(alignof(std::max_align_t), alignof(any<0, true, true, 0>));
 
     EXPECT_FALSE((any<1>{}.has_value()));
-    EXPECT_EQ(sizeof(std::max_align_t), alignof(any<1>));
+    EXPECT_EQ(alignof(std::max_align_t), alignof(any<1>));
     EXPECT_FALSE((any<1, false>{}.has_value()));
     EXPECT_FALSE((any<1, false, true>{}.has_value()));
     EXPECT_FALSE((any<1, true, false>{}.has_value()));

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -105,27 +105,22 @@ TEST(test_any, cppref_example)
 TEST(test_any, ctor_1_default)
 {
     EXPECT_FALSE((any<0>{}.has_value()));
-    EXPECT_EQ(alignof(std::max_align_t), alignof(any<0>));
     EXPECT_FALSE((any<0, false>{}.has_value()));
     EXPECT_FALSE((any<0, false, true>{}.has_value()));
     EXPECT_FALSE((any<0, true, false>{}.has_value()));
-    EXPECT_FALSE((any<0, true, true, 0>{}.has_value()));
-    EXPECT_EQ(alignof(std::max_align_t), alignof(any<0, true, true, 0>));
+    EXPECT_FALSE((any<0, true, true, 1>{}.has_value()));
 
     EXPECT_FALSE((any<1>{}.has_value()));
-    EXPECT_EQ(alignof(std::max_align_t), alignof(any<1>));
     EXPECT_FALSE((any<1, false>{}.has_value()));
     EXPECT_FALSE((any<1, false, true>{}.has_value()));
     EXPECT_FALSE((any<1, true, false>{}.has_value()));
-    EXPECT_FALSE((any<1, true, false, 1>{}.has_value()));
-    EXPECT_EQ(256, alignof(any<1, true, true, 256>));
+    EXPECT_FALSE((any<1, true, true, 1>{}.has_value()));
 
     EXPECT_FALSE((any<13>{}.has_value()));
-    EXPECT_EQ(sizeof(std::max_align_t), alignof(any<13>));
     EXPECT_FALSE((any<13, false>{}.has_value()));
     EXPECT_FALSE((any<13, false, true>{}.has_value()));
     EXPECT_FALSE((any<13, true, false>{}.has_value()));
-    EXPECT_EQ(256, alignof(any<13, true, true, 256>));
+    EXPECT_FALSE((any<13, true, true, 1>{}.has_value()));
 }
 
 TEST(test_any, ctor_2_copy)

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -20,31 +20,31 @@ namespace cetl
 {
 
 // Forward declarations
-template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Align>
+template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment>
 class any;
 
 namespace detail
 {
 
 // Move policy.
-template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Align>
+template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment>
 struct base_move;
 
 // Copy policy.
-template <std::size_t Footprint, bool Copyable, std::size_t Align>
+template <std::size_t Footprint, bool Copyable, std::size_t Alignment>
 struct base_copy;
 
-template <std::size_t Footprint, std::size_t Align>
+template <std::size_t Footprint, std::size_t Alignment>
 struct base_storage
 {
     // We need to align the buffer to the given value (maximum alignment by default).
     // Also, we need to ensure that the buffer is at least 1 byte long.
-    alignas(Align) char buffer_[std::max(Footprint, 1UL)];
+    alignas(Alignment) char buffer_[std::max(Footprint, 1UL)];
 };
 
 // Movable case.
-template <std::size_t Footprint, bool Copyable, std::size_t Align>
-struct base_move<Footprint, Copyable, true, Align> : base_copy<Footprint, Copyable, Align>
+template <std::size_t Footprint, bool Copyable, std::size_t Alignment>
+struct base_move<Footprint, Copyable, true, Alignment> : base_copy<Footprint, Copyable, Alignment>
 {
 public:
     constexpr base_move()                      = default;
@@ -53,8 +53,8 @@ public:
 };
 
 // Non-movable case.
-template <std::size_t Footprint, bool Copyable, std::size_t Align>
-struct base_move<Footprint, Copyable, false, Align> : base_copy<Footprint, Copyable, Align>
+template <std::size_t Footprint, bool Copyable, std::size_t Alignment>
+struct base_move<Footprint, Copyable, false, Alignment> : base_copy<Footprint, Copyable, Alignment>
 {
 public:
     constexpr base_move()                      = default;
@@ -63,8 +63,8 @@ public:
 };
 
 // Copyable case.
-template <std::size_t Footprint, std::size_t Align>
-struct base_copy<Footprint, true, Align> : base_storage<Footprint, Align>
+template <std::size_t Footprint, std::size_t Alignment>
+struct base_copy<Footprint, true, Alignment> : base_storage<Footprint, Alignment>
 {
 public:
     constexpr base_copy()                  = default;
@@ -73,8 +73,8 @@ public:
 };
 
 // Non-copyable case.
-template <std::size_t Footprint, std::size_t Align>
-struct base_copy<Footprint, false, Align> : base_storage<Footprint, Align>
+template <std::size_t Footprint, std::size_t Alignment>
+struct base_copy<Footprint, false, Alignment> : base_storage<Footprint, Alignment>
 {
 public:
     constexpr base_copy()                  = default;
@@ -102,10 +102,10 @@ enum class action
 }  // namespace detail
 
 template <std::size_t Footprint,
-          bool        Copyable = true,
-          bool        Movable  = Copyable,
-          std::size_t Align    = alignof(std::max_align_t)>
-class any : private detail::base_move<Footprint, Copyable, Movable, Align>
+          bool        Copyable  = true,
+          bool        Movable   = Copyable,
+          std::size_t Alignment = alignof(std::max_align_t)>
+class any : private detail::base_move<Footprint, Copyable, Movable, Alignment>
 {
 public:
     constexpr any() noexcept = default;

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -20,21 +20,21 @@ namespace cetl
 {
 
 // Forward declarations
-template <std::size_t Footprint, bool Copyable, bool Movable>
+template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Align>
 class any;
 
 namespace detail
 {
 
 // Move policy.
-template <std::size_t Footprint, bool Copyable, bool Movable>
+template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Align>
 struct base_move;
 
 // Copy policy.
-template <std::size_t Footprint, bool Copyable>
+template <std::size_t Footprint, bool Copyable, std::size_t Align>
 struct base_copy;
 
-template <std::size_t Footprint, std::size_t Align = sizeof(std::max_align_t)>
+template <std::size_t Footprint, std::size_t Align>
 struct base_storage
 {
     // We need to align the buffer to the given value (maximum alignment by default).
@@ -43,8 +43,8 @@ struct base_storage
 };
 
 // Movable case.
-template <std::size_t Footprint, bool Copyable>
-struct base_move<Footprint, Copyable, true> : base_copy<Footprint, Copyable>
+template <std::size_t Footprint, bool Copyable, std::size_t Align>
+struct base_move<Footprint, Copyable, true, Align> : base_copy<Footprint, Copyable, Align>
 {
 public:
     constexpr base_move()                      = default;
@@ -53,8 +53,8 @@ public:
 };
 
 // Non-movable case.
-template <std::size_t Footprint, bool Copyable>
-struct base_move<Footprint, Copyable, false> : base_copy<Footprint, Copyable>
+template <std::size_t Footprint, bool Copyable, std::size_t Align>
+struct base_move<Footprint, Copyable, false, Align> : base_copy<Footprint, Copyable, Align>
 {
 public:
     constexpr base_move()                      = default;
@@ -63,8 +63,8 @@ public:
 };
 
 // Copyable case.
-template <std::size_t Footprint>
-struct base_copy<Footprint, true> : base_storage<Footprint>
+template <std::size_t Footprint, std::size_t Align>
+struct base_copy<Footprint, true, Align> : base_storage<Footprint, Align>
 {
 public:
     constexpr base_copy()                  = default;
@@ -73,8 +73,8 @@ public:
 };
 
 // Non-copyable case.
-template <std::size_t Footprint>
-struct base_copy<Footprint, false> : base_storage<Footprint>
+template <std::size_t Footprint, std::size_t Align>
+struct base_copy<Footprint, false, Align> : base_storage<Footprint, Align>
 {
 public:
     constexpr base_copy()                  = default;
@@ -101,8 +101,11 @@ enum class action
 
 }  // namespace detail
 
-template <std::size_t Footprint, bool Copyable = true, bool Movable = Copyable>
-class any : private detail::base_move<Footprint, Copyable, Movable>
+template <std::size_t Footprint,
+          bool        Copyable = true,
+          bool        Movable  = Copyable,
+          std::size_t Align    = alignof(std::max_align_t)>
+class any : private detail::base_move<Footprint, Copyable, Movable, Align>
 {
 public:
     constexpr any() noexcept = default;


### PR DESCRIPTION
Also:
- Fixed `sizeof` → `alignof`.
- Added `TestMovableOnly` helper, and assign operators.
- Reduced code duplication in tests (`TestCopyable` & `TestCopyableAndMovable`).