### PR TITLE
Reworked handling of get, copy, move and destroy functionality.

### DIFF
--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -94,11 +94,13 @@ struct TestCopyableAndMovable
 
     TestCopyableAndMovable& operator=(const TestCopyableAndMovable& other)
     {
+        moved_ = false;
         value_ = other.value_ + 10;
         return *this;
     }
     TestCopyableAndMovable& operator=(TestCopyableAndMovable&& other) noexcept
     {
+        moved_       = false;
         value_       = other.value_ + 1;
         other.moved_ = true;
         return *this;

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -618,13 +618,13 @@ TEST(test_any, swap_movable)
     // Self swap
     a.swap(std::move(a));
     EXPECT_TRUE(a.has_value());
-    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('A', any_cast<const test&>(a).payload_);
 
     a.swap(std::move(b));
     EXPECT_TRUE(a.has_value());
     EXPECT_TRUE(b.has_value());
-    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
     // EXPECT_FALSE(any_cast<test&>(b).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
     EXPECT_EQ('A', any_cast<test&>(b).payload_);
@@ -632,7 +632,7 @@ TEST(test_any, swap_movable)
     empty.swap(std::move(a));
     EXPECT_FALSE(a.has_value());
     EXPECT_TRUE(empty.has_value());
-    EXPECT_FALSE(any_cast<test&>(empty).moved_);
+    // EXPECT_FALSE(any_cast<test&>(empty).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(empty).payload_);
 
     empty.swap(std::move(a));

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -64,6 +64,7 @@ struct TestMovableOnly
     TestMovableOnly& operator=(const TestMovableOnly& other) = delete;
     TestMovableOnly& operator=(TestMovableOnly&& other) noexcept
     {
+        moved_   = false;
         payload_ = other.payload_;
         value_   = other.value_ + 1;
 

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -44,7 +44,7 @@ struct TestMovableOnly
 {
     char payload_;
     int  value_ = 0;
-    bool moved_ = false;
+    std::atomic<bool> moved_{false};
 
     explicit TestMovableOnly(const char payload = '?')
         : payload_(payload)
@@ -78,7 +78,7 @@ struct TestMovableOnly
 struct TestCopyableAndMovable
 {
     int  value_ = 0;
-    bool moved_ = false;
+    std::atomic<bool> moved_{false};
 
     TestCopyableAndMovable() = default;
     TestCopyableAndMovable(const TestCopyableAndMovable& other)
@@ -616,33 +616,33 @@ TEST(test_any, swap_movable)
     uut b{'B'};
 
     // Self swap
-    a.swap(std::move(a));
+    a.swap(a);
     EXPECT_TRUE(a.has_value());
-    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(a).moved_);
     EXPECT_EQ('A', any_cast<const test&>(a).payload_);
 
-    a.swap(std::move(b));
+    a.swap(b);
     EXPECT_TRUE(a.has_value());
     EXPECT_TRUE(b.has_value());
-    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
-    // EXPECT_FALSE(any_cast<test&>(b).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    EXPECT_FALSE(any_cast<test&>(b).moved_);
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
     EXPECT_EQ('A', any_cast<test&>(b).payload_);
 
-    empty.swap(std::move(a));
+    empty.swap(a);
     EXPECT_FALSE(a.has_value());
     EXPECT_TRUE(empty.has_value());
-    // EXPECT_FALSE(any_cast<test&>(empty).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(empty).moved_);
     EXPECT_EQ('B', any_cast<test&>(empty).payload_);
 
-    empty.swap(std::move(a));
+    empty.swap(a);
     EXPECT_TRUE(a.has_value());
     EXPECT_FALSE(empty.has_value());
-    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(a).moved_);
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
 
     uut another_empty{};
-    empty.swap(std::move(another_empty));
+    empty.swap(another_empty);
     EXPECT_FALSE(empty.has_value());
     EXPECT_FALSE(another_empty.has_value());
 }

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -44,7 +44,7 @@ struct TestMovableOnly
 {
     char payload_;
     int  value_ = 0;
-    std::atomic<bool> moved_{false};
+    bool moved_ = false;
 
     explicit TestMovableOnly(const char payload = '?')
         : payload_(payload)
@@ -78,7 +78,7 @@ struct TestMovableOnly
 struct TestCopyableAndMovable
 {
     int  value_ = 0;
-    std::atomic<bool> moved_{false};
+    bool moved_ = false;
 
     TestCopyableAndMovable() = default;
     TestCopyableAndMovable(const TestCopyableAndMovable& other)
@@ -618,27 +618,27 @@ TEST(test_any, swap_movable)
     // Self swap
     a.swap(a);
     EXPECT_TRUE(a.has_value());
-    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('A', any_cast<const test&>(a).payload_);
 
     a.swap(b);
     EXPECT_TRUE(a.has_value());
     EXPECT_TRUE(b.has_value());
-    EXPECT_FALSE(any_cast<test&>(a).moved_);
-    EXPECT_FALSE(any_cast<test&>(b).moved_);
+    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
+    // EXPECT_FALSE(any_cast<test&>(b).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
     EXPECT_EQ('A', any_cast<test&>(b).payload_);
 
     empty.swap(a);
     EXPECT_FALSE(a.has_value());
     EXPECT_TRUE(empty.has_value());
-    EXPECT_FALSE(any_cast<test&>(empty).moved_);
+    // EXPECT_FALSE(any_cast<test&>(empty).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(empty).payload_);
 
     empty.swap(a);
     EXPECT_TRUE(a.has_value());
     EXPECT_FALSE(empty.has_value());
-    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
 
     uut another_empty{};

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -814,36 +814,36 @@ TEST(test_any, swap_copyable)
 TEST(test_any, swap_movable)
 {
     using test = TestMovableOnly;
-    using uut  = any<sizeof(test)>;
+    using uut  = any<sizeof(test), false, true>;
 
     uut empty{};
-    uut a{'A'};
-    uut b{'B'};
+    uut a{in_place_type_t<test>{}, 'A'};
+    uut b{in_place_type_t<test>{}, 'B'};
 
     // Self swap
     a.swap(a);
     EXPECT_TRUE(a.has_value());
-    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(a).moved_);
     EXPECT_EQ('A', any_cast<const test&>(a).payload_);
 
     a.swap(b);
     EXPECT_TRUE(a.has_value());
     EXPECT_TRUE(b.has_value());
-    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
-    // EXPECT_FALSE(any_cast<test&>(b).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    EXPECT_FALSE(any_cast<test&>(b).moved_);
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
     EXPECT_EQ('A', any_cast<test&>(b).payload_);
 
     empty.swap(a);
     EXPECT_FALSE(a.has_value());
     EXPECT_TRUE(empty.has_value());
-    // EXPECT_FALSE(any_cast<test&>(empty).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(empty).moved_);
     EXPECT_EQ('B', any_cast<test&>(empty).payload_);
 
     empty.swap(a);
     EXPECT_TRUE(a.has_value());
     EXPECT_FALSE(empty.has_value());
-    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
+    EXPECT_FALSE(any_cast<test&>(a).moved_);
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
 
     uut another_empty{};

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -638,7 +638,7 @@ TEST(test_any, swap_movable)
     empty.swap(std::move(a));
     EXPECT_TRUE(a.has_value());
     EXPECT_FALSE(empty.has_value());
-    EXPECT_FALSE(any_cast<test&>(a).moved_);
+    // EXPECT_FALSE(any_cast<test&>(a).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
 
     uut another_empty{};

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -625,7 +625,7 @@ TEST(test_any, swap_movable)
     EXPECT_TRUE(a.has_value());
     EXPECT_TRUE(b.has_value());
     EXPECT_FALSE(any_cast<test&>(a).moved_);
-    EXPECT_FALSE(any_cast<test&>(b).moved_);
+    // EXPECT_FALSE(any_cast<test&>(b).moved_); //< TODO: Figure out why it fails on CI!
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
     EXPECT_EQ('A', any_cast<test&>(b).payload_);
 

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -300,7 +300,7 @@ public:
 
     any& operator=(const any& rhs)
     {
-        any(rhs).swap(std::move(*this));
+        any(rhs).swap(*this);
         return *this;
     }
 
@@ -344,7 +344,9 @@ public:
         base::reset();
     }
 
-    template <typename = std::enable_if<Copyable && !Movable>>
+    template <bool CopyableAlias = Copyable,
+              bool MovableAlias  = Movable,
+              typename           = std::enable_if_t<CopyableAlias && !MovableAlias>>
     void swap(any& rhs)
     {
         if (this == &rhs)
@@ -373,8 +375,8 @@ public:
         }
     }
 
-    template <typename = std::enable_if<Movable>>
-    void swap(any&& rhs) noexcept
+    template <bool MovableAlias = Movable, typename = std::enable_if_t<MovableAlias>>
+    void swap(any& rhs) noexcept
     {
         if (this == &rhs)
         {

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -113,6 +113,7 @@ private:
 
     // Holds type-erased value destroyer. `nullptr` if storage has no value stored.
     void (*value_destroyer_)(void* self) = nullptr;
+
 };  // base_storage
 
 // Copy policy.
@@ -365,7 +366,7 @@ public:
             if (rhs.has_value())
             {
                 any tmp{rhs};
-                static_cast<base&>(rhs) = *this;
+                static_cast<base&>(rhs)   = *this;
                 static_cast<base&>(*this) = tmp;
             }
             else
@@ -394,7 +395,7 @@ public:
             if (rhs.has_value())
             {
                 any tmp{std::move(rhs)};
-                static_cast<base&>(rhs) = std::move(*this);
+                static_cast<base&>(rhs)   = std::move(*this);
                 static_cast<base&>(*this) = std::move(tmp);
             }
             else

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -117,9 +117,6 @@ struct base_handlers<Footprint, false, false, Alignment> : base_storage<Footprin
 template <std::size_t Footprint, std::size_t Alignment>
 struct base_handlers<Footprint, true, false, Alignment> : base_storage<Footprint, Alignment>
 {
-    // Holds type-erased value copyer. `nullptr` when copy operation is not supported.
-    void (*value_copier_)(const void* src, void* dst) = nullptr;
-
     void copy_handlers_from(const base_handlers& src) noexcept
     {
         base::copy_handlers_from(src);
@@ -132,6 +129,9 @@ struct base_handlers<Footprint, true, false, Alignment> : base_storage<Footprint
         base::reset();
     }
 
+    // Holds type-erased value copyer. `nullptr` when copy operation is not supported.
+    void (*value_copier_)(const void* src, void* dst) = nullptr;
+
 private:
     using base = base_storage<Footprint, Alignment>;
 };
@@ -139,9 +139,6 @@ private:
 template <std::size_t Footprint, std::size_t Alignment>
 struct base_handlers<Footprint, false, true, Alignment> : base_storage<Footprint, Alignment>
 {
-    // Holds type-erased value mover. `nullptr` when move operation is not supported.
-    void (*value_mover_)(void* src, void* dst) = nullptr;
-
     void copy_handlers_from(const base_handlers& src) noexcept
     {
         base::copy_handlers_from(src);
@@ -154,6 +151,9 @@ struct base_handlers<Footprint, false, true, Alignment> : base_storage<Footprint
         base::reset();
     }
 
+    // Holds type-erased value mover. `nullptr` when move operation is not supported.
+    void (*value_mover_)(void* src, void* dst) = nullptr;
+
 private:
     using base = base_storage<Footprint, Alignment>;
 };
@@ -161,12 +161,6 @@ private:
 template <std::size_t Footprint, std::size_t Alignment>
 struct base_handlers<Footprint, true, true, Alignment> : base_storage<Footprint, Alignment>
 {
-    // Holds type-erased value copyer. `nullptr` when copy operation is not supported.
-    void (*value_copier_)(const void* src, void* dst) = nullptr;
-
-    // Holds type-erased value mover. `nullptr` when move operation is not supported.
-    void (*value_mover_)(void* src, void* dst) = nullptr;
-
     void copy_handlers_from(const base_handlers& src) noexcept
     {
         base::copy_handlers_from(src);
@@ -182,6 +176,12 @@ struct base_handlers<Footprint, true, true, Alignment> : base_storage<Footprint,
 
         base::reset();
     }
+
+    // Holds type-erased value copyer. `nullptr` when copy operation is not supported.
+    void (*value_copier_)(const void* src, void* dst) = nullptr;
+
+    // Holds type-erased value mover. `nullptr` when move operation is not supported.
+    void (*value_mover_)(void* src, void* dst) = nullptr;
 
 private:
     using base = base_storage<Footprint, Alignment>;

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -116,7 +116,7 @@ public:
 
             value_mover_(src.get_raw_storage(), get_raw_storage());
 
-            src.reset(false);
+            src.reset();
         }
     }
 
@@ -127,16 +127,16 @@ public:
         value_mover_     = src.value_mover_;
     }
 
-    void reset(const bool destroy = true) noexcept
+    void reset() noexcept
     {
-        if (destroy && value_destroyer_)
+        if (value_destroyer_)
         {
             value_destroyer_(get_raw_storage());
+            value_destroyer_ = nullptr;
         }
 
-        value_destroyer_ = nullptr;
-        value_copier_    = nullptr;
-        value_mover_     = nullptr;
+        value_copier_ = nullptr;
+        value_mover_  = nullptr;
     }
 
 };  // base_storage
@@ -341,7 +341,7 @@ public:
 
     void reset() noexcept
     {
-        base::reset(true);
+        base::reset();
     }
 
     template <typename = std::enable_if<Copyable && !Movable>>


### PR DESCRIPTION
- Now `Copyable` and `Movable` constraints are respected.
- Now instead of single handler we have 3 (destroyer, copier, mover) - allows to eliminate AUTOSAR `const_cast` violations.
- In unit tests:
  - more tests to cover combinations of `any` template params
  - switch from pointer based `any_cast` to value or reference based.