### PR TITLE
Fixed missing `remove_cv_t` at `any_cast` # 5

### DIFF
--- a/cetlvast/suites/docs/examples/example_10_any.cpp
+++ b/cetlvast/suites/docs/examples/example_10_any.cpp
@@ -1,0 +1,70 @@
+/// @file
+/// Example of using cetl::any.
+///
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+///
+#include "cetl/any.hpp"
+
+#include <gtest/gtest.h>
+
+//! [example_10_any_type_id]
+namespace cetl
+{
+template <>
+constexpr type_id type_id_value<bool> = {1};
+template <>
+constexpr type_id type_id_value<int> = {2};
+template <>
+constexpr type_id type_id_value<float> = {3};
+template <>
+constexpr type_id type_id_value<double> = {4};
+
+}  // namespace cetl
+//! [example_10_any_type_id]
+
+TEST(example_10_any, basic_usage)
+{
+    //! [example_10_any_basic_usage]
+    /// This example is inspired by the [cppreference.com](https://en.cppreference.com/w/cpp/utility/any)
+    /// documentation.
+    using any = cetl::any<std::max(sizeof(int), sizeof(double))>;
+
+    any a = 1;
+    EXPECT_EQ(1, cetl::any_cast<int>(a));
+
+    a = 3.14;
+    EXPECT_EQ(3.14, cetl::any_cast<double>(a));
+
+    a = true;
+    EXPECT_TRUE(cetl::any_cast<bool>(a));
+
+    // bad any cast
+    //
+    a = 1;
+#if defined(__cpp_exceptions)
+    // Workaround for GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
+    // Should be used in the tests where exceptions are expected (see `EXPECT_THROW`).
+    const auto sink = [](auto&&) {};
+
+    EXPECT_THROW(sink(cetl::any_cast<float>(a)), cetl::bad_any_cast);
+#else
+    EXPECT_EQ(nullptr, cetl::any_cast<float>(&a));
+#endif
+
+    a = 2;
+    EXPECT_TRUE(a.has_value());
+
+    // reset
+    //
+    a.reset();
+    EXPECT_FALSE(a.has_value());
+
+    // pointer to contained data
+    //
+    a = 3;
+    EXPECT_EQ(3, *cetl::any_cast<int>(&a));
+    //! [example_10_any_basic_usage]
+}

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -681,10 +681,19 @@ TEST(test_any, make_any_cppref_example)
 
 TEST(test_any, make_any_1)
 {
-    using any = const any<sizeof(int)>;
+    using any = any<sizeof(int), false, true, 16>;
 
-    const auto test = make_any<int, any>(42);
-    EXPECT_EQ(42, any_cast<int>(test));
+    auto src = make_any<int, any>(42);
+    EXPECT_EQ(42, any_cast<int>(src));
+    static_assert(std::is_same<decltype(src), any>::value, "");
+}
+
+TEST(test_any, make_any_1_like)
+{
+    auto src = make_any<uint16_t>(static_cast<uint16_t>(42));
+    EXPECT_EQ(42, any_cast<uint16_t>(src));
+    static_assert(std::is_same<decltype(src), cetl::any_like<uint16_t>>::value, "");
+    static_assert(std::is_same<decltype(src), cetl::any<sizeof(uint16_t), true, true, alignof(uint16_t)>>::value, "");
 }
 
 TEST(test_any, make_any_2_list)
@@ -706,6 +715,13 @@ TEST(test_any, make_any_2_list)
     const auto& test = any_cast<const TestType&>(src);
     EXPECT_EQ(2, test.size_);
     EXPECT_EQ(42, test.number_);
+
+    // `cetl::any_like` version
+    //
+    const auto dst = make_any<TestType>({'B', 'D', 'E'}, 147);
+    static_assert(std::is_same<decltype(dst), const cetl::any_like<TestType>>::value, "");
+    EXPECT_EQ(3, any_cast<TestType>(&dst)->size_);
+    EXPECT_EQ(147, any_cast<const TestType&>(dst).number_);
 }
 
 TEST(test_any, any_cast_cppref_example)
@@ -1057,6 +1073,9 @@ constexpr type_id type_id_value<char> = {5};
 
 template <>
 constexpr type_id type_id_value<std::string> = {6};
+
+template <>
+constexpr type_id type_id_value<uint16_t> = {7};
 
 template <>
 constexpr type_id type_id_value<std::unique_ptr<TestCopyableAndMovable>> =

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -320,10 +320,10 @@ TEST(test_any, ctor_2_copy)
 {
     // Primitive `int`
     {
-        using uut = any<sizeof(int)>;
+        using any = any<sizeof(int)>;
 
-        const uut src{42};
-        uut       dst{src};
+        const any src{42};
+        any       dst{src};
 
         EXPECT_EQ(42, any_cast<int>(src));
         EXPECT_EQ(42, any_cast<int>(dst));
@@ -332,10 +332,10 @@ TEST(test_any, ctor_2_copy)
     // Copyable and Movable `any`
     {
         using test = TestCopyableAndMovable;
-        using uut  = any<sizeof(test)>;
+        using any  = any<sizeof(test)>;
 
-        const uut src{test{}};
-        uut       dst{src};
+        const any src{test{}};
+        any       dst{src};
 
         EXPECT_EQ(1 + 10, any_cast<test>(src).value_);
         EXPECT_EQ(1, any_cast<const test&>(src).value_);
@@ -352,11 +352,11 @@ TEST(test_any, ctor_2_copy)
     // Copyable only `any`
     {
         using test = TestCopyableOnly;
-        using uut  = any<sizeof(test), true, false>;
+        using any  = any<sizeof(test), true, false>;
 
         const test value{};
-        uut        src{value};
-        const uut  dst{src};
+        any        src{value};
+        const any  dst{src};
 
         EXPECT_EQ(10, any_cast<test&>(src).value_);
         EXPECT_EQ(10, any_cast<const test&>(src).value_);
@@ -367,7 +367,7 @@ TEST(test_any, ctor_2_copy)
     // Movable only `any`
     {
         using test = TestMovableOnly;
-        using uut  = any<sizeof(test), false, true>;
+        using any  = any<sizeof(test), false, true>;
 
         test value{'X'};
         EXPECT_FALSE(value.moved_);
@@ -379,23 +379,23 @@ TEST(test_any, ctor_2_copy)
         EXPECT_FALSE(value2.moved_);
         EXPECT_EQ(1, value2.value_);
         EXPECT_EQ('X', value2.payload_);
-        // uut src{value}; //< expectedly won't compile (due to !copyable `test`)
-        uut src{std::move(value2)};
+        // any src{value}; //< expectedly won't compile (due to !copyable `test`)
+        any src{std::move(value2)};
         EXPECT_EQ('X', any_cast<test&>(src).payload_);
-        // const uut  dst{src}; //< expectedly won't compile (due to !copyable `any`)
+        // const any  dst{src}; //< expectedly won't compile (due to !copyable `any`)
     }
 
     // Non-Copyable and non-movable `any`
     {
         using test = TestCopyableAndMovable;
-        using uut  = any<sizeof(test), false>;
+        using any  = any<sizeof(test), false>;
 
-        uut src{test{}};
+        any src{test{}};
         EXPECT_EQ(1 + 10, any_cast<test>(src).value_);
         EXPECT_EQ(1, any_cast<test&>(src).value_);
         EXPECT_EQ(1 + 1, any_cast<test>(std::move(src)).value_);
-        // const uut  dst{src}; //< expectedly won't compile (due to !copyable `any`)
-        // uut dst{std::move(src)}; //< expectedly won't compile (due to !movable `any`)
+        // const any  dst{src}; //< expectedly won't compile (due to !copyable `any`)
+        // any dst{std::move(src)}; //< expectedly won't compile (due to !movable `any`)
     }
 }
 
@@ -403,10 +403,10 @@ TEST(test_any, ctor_3_move)
 {
     // Primitive `int`
     {
-        using uut = any<sizeof(int)>;
+        using any = any<sizeof(int)>;
 
-        uut       src{42};
-        const uut dst{std::move(src)};
+        any       src{42};
+        const any dst{std::move(src)};
 
         EXPECT_FALSE(src.has_value());
         EXPECT_EQ(42, any_cast<int>(dst));
@@ -415,12 +415,12 @@ TEST(test_any, ctor_3_move)
     // Copyable and Movable `any`
     {
         using test = TestCopyableAndMovable;
-        using uut  = any<sizeof(test)>;
+        using any  = any<sizeof(test)>;
 
-        uut src{test{}};
+        any src{test{}};
         EXPECT_TRUE(src.has_value());
 
-        const uut dst{std::move(src)};
+        const any dst{std::move(src)};
         EXPECT_TRUE(dst.has_value());
         EXPECT_FALSE(src.has_value());
         EXPECT_EQ(2, any_cast<const TestCopyableAndMovable&>(dst).value_);
@@ -429,10 +429,10 @@ TEST(test_any, ctor_3_move)
     // Movable only `any`
     {
         using test = TestMovableOnly;
-        using uut  = any<sizeof(test), false, true>;
+        using any  = any<sizeof(test), false, true>;
 
-        uut       src{test{'X'}};
-        const uut dst{std::move(src)};
+        any       src{test{'X'}};
+        const any dst{std::move(src)};
 
         EXPECT_EQ(nullptr, any_cast<test>(&src));
         EXPECT_EQ(2, any_cast<const test&>(dst).value_);
@@ -444,10 +444,10 @@ TEST(test_any, ctor_3_move)
     // Copyable only `any`, movable only `unique_ptr`
     {
         using test = std::unique_ptr<TestCopyableAndMovable>;
-        using uut  = any<sizeof(test), false, true>;
+        using any  = any<sizeof(test), false, true>;
 
-        uut src{std::make_unique<TestCopyableAndMovable>()};
-        uut dst{std::move(src)};
+        any src{std::make_unique<TestCopyableAndMovable>()};
+        any dst{std::move(src)};
         EXPECT_FALSE(src.has_value());
 
         auto ptr = any_cast<test>(std::move(dst));
@@ -459,10 +459,10 @@ TEST(test_any, ctor_3_move)
 TEST(test_any, ctor_4_move_value)
 {
     using test = TestCopyableAndMovable;
-    using uut  = any<sizeof(test)>;
+    using any  = any<sizeof(test)>;
 
     test      value{'Y'};
-    const uut dst{std::move(value)};
+    const any dst{std::move(value)};
     EXPECT_TRUE(value.moved_);
     EXPECT_TRUE(dst.has_value());
     EXPECT_EQ(1, any_cast<const test&>(dst).value_);
@@ -482,9 +482,9 @@ TEST(test_any, ctor_5_in_place)
             number_ = number;
         }
     };
-    using uut = any<sizeof(TestType)>;
+    using any = any<sizeof(TestType)>;
 
-    const uut src{in_place_type_t<TestType>{}, 'Y', 42};
+    const any src{in_place_type_t<TestType>{}, 'Y', 42};
 
     const auto test = any_cast<TestType>(src);
     EXPECT_EQ('Y', test.ch_);
@@ -504,9 +504,9 @@ TEST(test_any, ctor_6_in_place_initializer_list)
             number_ = number;
         }
     };
-    using uut = any<sizeof(TestType)>;
+    using any = any<sizeof(TestType)>;
 
-    const uut src{in_place_type_t<TestType>{}, {'A', 'B', 'C'}, 42};
+    const any src{in_place_type_t<TestType>{}, {'A', 'B', 'C'}, 42};
 
     auto& test = any_cast<const TestType&>(src);
     EXPECT_EQ(3, test.size_);
@@ -517,12 +517,12 @@ TEST(test_any, assign_1_copy)
 {
     // Primitive `int`
     {
-        using uut = any<sizeof(int)>;
+        using any = any<sizeof(int)>;
 
-        const uut src{42};
+        const any src{42};
         EXPECT_TRUE(src.has_value());
 
-        uut dst{};
+        any dst{};
         EXPECT_FALSE(dst.has_value());
 
         dst = src;
@@ -530,11 +530,11 @@ TEST(test_any, assign_1_copy)
         EXPECT_TRUE(dst.has_value());
         EXPECT_EQ(42, any_cast<int>(dst));
 
-        const uut src2{147};
+        const any src2{147};
         dst = src2;
         EXPECT_EQ(147, any_cast<int>(dst));
 
-        const uut empty{};
+        const any empty{};
         dst = empty;
         EXPECT_FALSE(dst.has_value());
     }
@@ -544,17 +544,17 @@ TEST(test_any, assign_1_copy)
     side_effect_stats stats;
     {
         using test = TestCopyableOnly;
-        using uut  = any<sizeof(test), true, false>;
+        using any  = any<sizeof(test), true, false>;
 
         auto side_effects = stats.make_side_effect_fn();
 
         const test value1{'X', side_effects};
         EXPECT_STREQ("@", stats.ops.c_str());
 
-        const uut src1{value1};
+        const any src1{value1};
         EXPECT_STREQ("@C", stats.ops.c_str());
 
-        uut dst{};
+        any dst{};
         dst = src1;
         EXPECT_STREQ("@CCC~", stats.ops.c_str());
 
@@ -566,7 +566,7 @@ TEST(test_any, assign_1_copy)
         const test value2{'Z', side_effects};
         EXPECT_STREQ("@CCC~@", stats.ops.c_str());
 
-        const uut src2{value2};
+        const any src2{value2};
         EXPECT_STREQ("@CCC~@C", stats.ops.c_str());
 
         dst = src2;
@@ -589,12 +589,12 @@ TEST(test_any, assign_2_move)
 {
     // Primitive `int`
     {
-        using uut = any<sizeof(int)>;
+        using any = any<sizeof(int)>;
 
-        uut src{42};
+        any src{42};
         EXPECT_TRUE(src.has_value());
 
-        uut dst{};
+        any dst{};
         EXPECT_FALSE(dst.has_value());
 
         dst = std::move(src);
@@ -602,14 +602,14 @@ TEST(test_any, assign_2_move)
         EXPECT_FALSE(src.has_value());
         EXPECT_EQ(42, any_cast<int>(dst));
 
-        dst = uut{147};
+        dst = any{147};
         EXPECT_EQ(147, any_cast<int>(dst));
 
         auto dst_ptr = &dst;
         dst          = std::move(*dst_ptr);
         EXPECT_EQ(147, any_cast<int>(dst));
 
-        dst = uut{};
+        dst = any{};
         EXPECT_FALSE(dst.has_value());
     }
 
@@ -618,14 +618,14 @@ TEST(test_any, assign_2_move)
     side_effect_stats stats;
     {
         using test = TestMovableOnly;
-        using uut  = any<sizeof(test), false, true>;
+        using any  = any<sizeof(test), false, true>;
 
         auto side_effects = stats.make_side_effect_fn();
 
-        uut src1{test{'X', side_effects}};
+        any src1{test{'X', side_effects}};
         EXPECT_STREQ("@M_", stats.ops.c_str());
 
-        uut dst{};
+        any dst{};
         dst = std::move(src1);
         EXPECT_STREQ("@M_M_M_", stats.ops.c_str());
 
@@ -633,7 +633,7 @@ TEST(test_any, assign_2_move)
         EXPECT_EQ(3, any_cast<const test&>(dst).value_);
         EXPECT_EQ('X', any_cast<const test&>(dst).payload_);
 
-        uut src2{test{'Z', side_effects}};
+        any src2{test{'Z', side_effects}};
         EXPECT_STREQ("@M_M_M_@M_", stats.ops.c_str());
 
         dst = std::move(src2);
@@ -651,9 +651,9 @@ TEST(test_any, assign_3_move_value)
 {
     // Primitive `int`
     {
-        using uut = any<sizeof(int)>;
+        using any = any<sizeof(int)>;
 
-        uut dst{};
+        any dst{};
         EXPECT_FALSE(dst.has_value());
 
         dst = 147;
@@ -663,16 +663,16 @@ TEST(test_any, assign_3_move_value)
 
 TEST(test_any, make_any_cppref_example)
 {
-    using uut = any<std::max(sizeof(std::string), sizeof(std::complex<double>))>;
+    using any = any<std::max(sizeof(std::string), sizeof(std::complex<double>))>;
 
-    auto a0 = make_any<std::string, uut>("Hello, cetl::any!\n");
-    auto a1 = make_any<std::complex<double>, uut>(0.1, 2.3);
+    auto a0 = make_any<std::string, any>("Hello, cetl::any!\n");
+    auto a1 = make_any<std::complex<double>, any>(0.1, 2.3);
 
     EXPECT_STREQ("Hello, cetl::any!\n", any_cast<std::string>(a0).c_str());
     EXPECT_EQ(std::complex<double>(0.1, 2.3), any_cast<std::complex<double>>(a1));
 
     using lambda     = std::function<const char*()>;
-    using any_lambda = any<sizeof(lambda)>;
+    using any_lambda = cetl::any<sizeof(lambda)>;
 
     auto a3 = make_any<lambda, any_lambda>([] { return "Lambda #3.\n"; });
     EXPECT_TRUE(a3.has_value());
@@ -681,9 +681,9 @@ TEST(test_any, make_any_cppref_example)
 
 TEST(test_any, make_any_1)
 {
-    using uut = const any<sizeof(int)>;
+    using any = const any<sizeof(int)>;
 
-    const auto test = make_any<int, uut>(42);
+    const auto test = make_any<int, any>(42);
     EXPECT_EQ(42, any_cast<int>(test));
 }
 
@@ -700,9 +700,9 @@ TEST(test_any, make_any_2_list)
             number_ = number;
         }
     };
-    using uut = any<sizeof(TestType)>;
+    using any = any<sizeof(TestType)>;
 
-    const auto  src  = make_any<TestType, uut>({'A', 'C'}, 42);
+    const auto  src  = make_any<TestType, any>({'A', 'C'}, 42);
     const auto& test = any_cast<const TestType&>(src);
     EXPECT_EQ(2, test.size_);
     EXPECT_EQ(42, test.number_);
@@ -803,7 +803,7 @@ TEST(test_any, any_cast_3_move_primitive_int)
     EXPECT_TRUE(src.has_value());  //< technically still "has" the value, but moved out.
 
     EXPECT_EQ(42, any_cast<int>(any{42}));
-    // EXPECT_EQ(42, any_cast<int&>(uut{42})); //< won't compile expectedly
+    // EXPECT_EQ(42, any_cast<int&>(any{42})); //< won't compile expectedly
     EXPECT_EQ(42, any_cast<const int>(any{42}));
     EXPECT_EQ(42, any_cast<const int&>(any{42}));
 }
@@ -942,11 +942,11 @@ TEST(test_any, swap_copyable)
 TEST(test_any, swap_movable)
 {
     using test = TestMovableOnly;
-    using uut  = any<sizeof(test), false, true>;
+    using any  = any<sizeof(test), false, true>;
 
-    uut empty{};
-    uut a{in_place_type_t<test>{}, 'A'};
-    uut b{in_place_type_t<test>{}, 'B'};
+    any empty{};
+    any a{in_place_type_t<test>{}, 'A'};
+    any b{in_place_type_t<test>{}, 'B'};
 
     // Self swap
     a.swap(a);
@@ -974,7 +974,7 @@ TEST(test_any, swap_movable)
     EXPECT_FALSE(any_cast<test&>(a).moved_);
     EXPECT_EQ('B', any_cast<test&>(a).payload_);
 
-    uut another_empty{};
+    any another_empty{};
     empty.swap(another_empty);
     EXPECT_FALSE(empty.has_value());
     EXPECT_FALSE(another_empty.has_value());
@@ -984,9 +984,9 @@ TEST(test_any, emplace_1)
 {
     // Primitive `char`
     {
-        using uut = any<sizeof(char)>;
+        using any = any<sizeof(char)>;
 
-        uut src;
+        any src;
         src.emplace<char>('Y');
         EXPECT_EQ('Y', any_cast<char>(src));
     }
@@ -1004,9 +1004,9 @@ TEST(test_any, emplace_1)
                 number_ = number;
             }
         };
-        using uut = any<sizeof(TestType)>;
+        using any = any<sizeof(TestType)>;
 
-        uut t;
+        any t;
         t.emplace<TestType>('Y', 147);
         EXPECT_EQ('Y', any_cast<TestType>(t).ch_);
         EXPECT_EQ(147, any_cast<TestType>(t).number_);
@@ -1026,9 +1026,9 @@ TEST(test_any, emplace_2_initializer_list)
             number_ = number;
         }
     };
-    using uut = any<sizeof(TestType)>;
+    using any = any<sizeof(TestType)>;
 
-    uut src;
+    any src;
     src.emplace<TestType>({'A', 'B', 'C'}, 42);
 
     const auto test = any_cast<TestType>(src);

--- a/cetlvast/suites/unittest/test_any.cpp
+++ b/cetlvast/suites/unittest/test_any.cpp
@@ -839,9 +839,9 @@ TEST(test_any, any_cast_3_move_empty_bad_cast)
 
 TEST(test_any, any_cast_4_const_ptr)
 {
-    using any = const any<sizeof(int)>;
+    using any = any<sizeof(int)>;
 
-    any src{147};
+    const any src{147};
 
     auto int_ptr = any_cast<int>(&src);
     static_assert(std::is_same<const int*, decltype(int_ptr)>::value, "");
@@ -849,7 +849,11 @@ TEST(test_any, any_cast_4_const_ptr)
     EXPECT_TRUE(int_ptr);
     EXPECT_EQ(147, *int_ptr);
 
-    EXPECT_FALSE((any_cast<char, any>(nullptr)));
+    auto const_int_ptr = any_cast<const int>(&src);
+    static_assert(std::is_same<const int*, decltype(const_int_ptr)>::value, "");
+    EXPECT_EQ(int_ptr, const_int_ptr);
+
+    EXPECT_EQ(nullptr, any_cast<int>(static_cast<const any*>(nullptr)));
 }
 
 TEST(test_any, any_cast_5_non_const_ptr_with_custom_alignment)
@@ -866,7 +870,11 @@ TEST(test_any, any_cast_5_non_const_ptr_with_custom_alignment)
     EXPECT_EQ('Y', *char_ptr);
     EXPECT_EQ(0, reinterpret_cast<intptr_t>(char_ptr) & static_cast<std::intptr_t>(alignment - 1));
 
-    EXPECT_FALSE((any_cast<char, any>(static_cast<any*>(nullptr))));
+    auto const_char_ptr = any_cast<const char>(&src);
+    static_assert(std::is_same<const char*, decltype(const_char_ptr)>::value, "");
+    EXPECT_EQ(char_ptr, const_char_ptr);
+
+    EXPECT_EQ(nullptr, any_cast<char>(static_cast<any*>(nullptr)));
 }
 
 TEST(test_any, any_cast_polymorphic)
@@ -1027,6 +1035,7 @@ TEST(test_any, emplace_2_initializer_list)
     EXPECT_EQ(3, test.size_);
     EXPECT_EQ(42, test.number_);
 }
+
 }  // namespace
 
 namespace cetl

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -387,6 +387,13 @@ private:
 
 }  // namespace detail
 
+/// \brief The class `any` describes a type-safe container for single values of any copy and/or move constructible type.
+///
+/// \tparam Footprint Maximum size of a contained object (in bytes).
+/// \tparam Copyable Determines whether a contained object is copy constructible.
+/// \tparam Movable Determines whether a contained object is move constructible.
+/// \tparam Alignment Alignment of storage for a contained object.
+///
 template <std::size_t Footprint,
           bool        Copyable  = true,
           bool        Movable   = Copyable,
@@ -396,10 +403,17 @@ class any : detail::base_move<Footprint, Copyable, Movable, Alignment>
     using base = detail::base_move<Footprint, Copyable, Movable, Alignment>;
 
 public:
-    constexpr any()           = default;
-    any(const any& other)     = default;
+    /// \brief Constructs an empty `any` object.
+    constexpr any() = default;
+    /// \brief Constructs an `any` object with a copy of the content of `other`.
+    any(const any& other) = default;
+    /// \brief Constructs an `any` object with the content of `other` using move semantics.
     any(any&& other) noexcept = default;
 
+    /// \brief Constructs an `any` object with `value` using move semantics.
+    ///
+    /// \tparam ValueType Type of the value to be stored. Its size must be less than or equal to `Footprint`.
+    ///
     template <
         typename ValueType,
         typename Tp = std::decay_t<ValueType>,
@@ -409,23 +423,39 @@ public:
         create<Tp>(std::forward<ValueType>(value));
     }
 
+    /// \brief Constructs an `any` object with in place constructed value.
+    ///
+    /// \tparam ValueType Type of the value to be stored. Its size must be less than or equal to `Footprint`.
+    /// \tparam Args Types of arguments to be passed to the constructor of `ValueType`.
+    /// \param args Arguments to be forwarded to the constructor of `ValueType`.
+    ///
     template <typename ValueType, typename... Args, typename Tp = std::decay_t<ValueType>>
     explicit any(in_place_type_t<ValueType>, Args&&... args)
     {
         create<Tp>(std::forward<Args>(args)...);
     }
 
+    /// \brief Constructs an `any` object with in place constructed value.
+    ///
+    /// \tparam ValueType Type of the value to be stored. Its size must be less than or equal to `Footprint`.
+    /// \tparam Up Type of the elements of the initializer list.
+    /// \tparam Args Types of arguments to be passed to the constructor of `ValueType`.
+    /// \param list Initializer list to be forwarded to the constructor of `ValueType`.
+    /// \param args Arguments to be forwarded to the constructor of `ValueType`.
+    ///
     template <typename ValueType, typename Up, typename... Args, typename Tp = std::decay_t<ValueType>>
     explicit any(in_place_type_t<ValueType>, std::initializer_list<Up> list, Args&&... args)
     {
         create<Tp>(list, std::forward<Args>(args)...);
     }
 
+    /// \brief Destroys the contained object if there is one.
     ~any()
     {
         reset();
     }
 
+    /// \brief Assigns the content of `rhs` to `*this`.
     any& operator=(const any& rhs)
     {
         if (this != &rhs)
@@ -435,6 +465,7 @@ public:
         return *this;
     }
 
+    /// \brief Assigns the content of `rhs` to `*this` using move semantics.
     any& operator=(any&& rhs) noexcept
     {
         if (this != &rhs)
@@ -444,6 +475,10 @@ public:
         return *this;
     }
 
+    /// \brief Assigns `value` to `*this` using move semantics.
+    ///
+    /// \tparam ValueType Type of the value to be stored. Its size must be less than or equal to `Footprint`.
+    ///
     template <typename ValueType,
               typename Tp = std::decay_t<ValueType>,
               typename    = std::enable_if_t<!std::is_same<Tp, any>::value>>
@@ -453,6 +488,12 @@ public:
         return *this;
     }
 
+    /// \brief Emplaces a new value to `*this`.
+    ///
+    /// \tparam ValueType Type of the value to be stored. Its size must be less than or equal to `Footprint`.
+    /// \tparam Args Types of arguments to be passed to the constructor of `ValueType`.
+    /// \param args Arguments to be forwarded to the constructor of `ValueType`.
+    ///
     template <typename ValueType, typename... Args, typename Tp = std::decay_t<ValueType>>
     Tp& emplace(Args&&... args)
     {
@@ -461,6 +502,14 @@ public:
         return create<Tp>(std::forward<Args>(args)...);
     }
 
+    /// \brief Emplaces a new value to `*this`.
+    ///
+    /// \tparam ValueType Type of the value to be stored. Its size must be less than or equal to `Footprint`.
+    /// \tparam Up Type of the elements of the initializer list.
+    /// \tparam Args Types of arguments to be passed to the constructor of `ValueType`.
+    /// \param list Initializer list to be forwarded to the constructor of `ValueType`.
+    /// \param args Arguments to be forwarded to the constructor of `ValueType`.
+    ///
     template <typename ValueType, typename Up, typename... Args, typename Tp = std::decay_t<ValueType>>
     Tp& emplace(std::initializer_list<Up> list, Args&&... args)
     {
@@ -476,6 +525,10 @@ public:
         base::reset();
     }
 
+    /// \brief Swaps the content of `*this` with the content of `rhs` using copy semantics.
+    ///
+    /// In use for copyable-only `any` objects.
+    ///
     template <bool CopyableAlias = Copyable,
               bool MovableAlias  = Movable,
               typename           = std::enable_if_t<CopyableAlias && !MovableAlias>>
@@ -507,6 +560,10 @@ public:
         }
     }
 
+    /// \brief Swaps the content of `*this` with the content of `rhs` using move semantics.
+    ///
+    /// In use for moveable `any` objects.
+    ///
     template <bool MovableAlias = Movable, typename = std::enable_if_t<MovableAlias>>
     void swap(any& rhs) noexcept
     {
@@ -555,11 +612,22 @@ private:
 
 };  // class any
 
+/// \brief Typealias for `any` with the given `ValueType` with the default
+/// footprint, copyability, movability, and alignment of the `ValueType`.
+///
+/// In use by `cetl::make_any` overloads to make them close to `std::make_any`.
+///
+template <typename ValueType>
+using any_like = any<sizeof(ValueType),
+                     std::is_copy_constructible<ValueType>::value,
+                     std::is_move_constructible<ValueType>::value,
+                     alignof(ValueType)>;
+
 /// \brief Constructs an any object containing an object of type T, passing the provided arguments to T's constructor.
 ///
 /// Equivalent to `cetl::any(cetl::in_place_type<ValueType>, std::forward<Args>(args)...)`.
 ///
-template <typename ValueType, typename Any, typename... Args>
+template <typename ValueType, typename Any = any_like<ValueType>, typename... Args>
 CETL_NODISCARD Any make_any(Args&&... args)
 {
     return Any(in_place_type<ValueType>, std::forward<Args>(args)...);
@@ -569,7 +637,7 @@ CETL_NODISCARD Any make_any(Args&&... args)
 ///
 /// Equivalent to `cetl::any(cetl::in_place_type<ValueType>, list, std::forward<Args>(args)...)`.
 ///
-template <typename ValueType, typename Any, typename Up, typename... Args>
+template <typename ValueType, typename Any = any_like<ValueType>, typename Up, typename... Args>
 CETL_NODISCARD Any make_any(std::initializer_list<Up> list, Args&&... args)
 {
     return Any(in_place_type<ValueType>, list, std::forward<Args>(args)...);

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -687,7 +687,7 @@ CETL_NODISCARD std::add_pointer_t<ValueType> any_cast(Any* const operand) noexce
     }
 
     using RawValueType = std::remove_cv_t<ValueType>;
-    const auto ptr = operand->template get_ptr<RawValueType>();
+    const auto ptr     = operand->template get_ptr<RawValueType>();
 
     using ReturnType = std::add_pointer_t<ValueType>;
     return static_cast<ReturnType>(ptr);

--- a/include/cetl/any.hpp
+++ b/include/cetl/any.hpp
@@ -686,7 +686,8 @@ CETL_NODISCARD std::add_pointer_t<ValueType> any_cast(Any* const operand) noexce
         return nullptr;
     }
 
-    const auto ptr = operand->template get_ptr<ValueType>();
+    using RawValueType = std::remove_cv_t<ValueType>;
+    const auto ptr = operand->template get_ptr<RawValueType>();
 
     using ReturnType = std::add_pointer_t<ValueType>;
     return static_cast<ReturnType>(ptr);

--- a/include/cetl/cetl.hpp
+++ b/include/cetl/cetl.hpp
@@ -29,6 +29,8 @@
 /// - @subpage example_06_memory_resource_deleter
 /// - @subpage example_07_polymorphic_alloc_deleter
 /// - @subpage example_08_variable_length_array_vs_vector
+/// - @subpage example_09_variant
+/// - @subpage example_10_any
 ///
 /// @page example_01_polyfill_20 Example 1: CETL C++20 Polyfill Header
 /// Full example for @ref cetl/pf20/cetlpf.hpp
@@ -62,6 +64,14 @@
 /// @page example_08_variable_length_array_vs_vector Example 8: Comparing std::vector to CETL's VariableLengthArray
 /// Full example for cetl::VariableLengthArray
 /// @include example_08_variable_length_array_vs_vector.cpp
+///
+/// @page example_09_variant Example 9: Using CETL's variant
+/// Full example for cetl::variant
+/// @include example_09_variant.cpp
+///
+/// @page example_10_any Example 10: Using CETL's any
+/// Full example for cetl::any
+/// @include example_10_any.cpp
 ///
 
 #ifndef CETL_H_INCLUDED

--- a/include/cetl/pf17/any.hpp
+++ b/include/cetl/pf17/any.hpp
@@ -20,8 +20,10 @@ namespace pf17
 
 #if defined(__cpp_exceptions) || defined(CETL_DOXYGEN)
 
-/// A polyfill for `std::bad_any_cast`.
+/// \brief A polyfill for `std::bad_any_cast`.
+///
 /// This is only available if exceptions are enabled (`__cpp_exceptions` is defined).
+///
 class bad_any_cast : public std::bad_cast
 {
 public:


### PR DESCRIPTION
- Extended corresponding unit test to cover this case.
- Renamed `uut` → `any` in all `test_any` unit tests.