### PR TITLE
PMR support for `cetl::unbounded_variant` & `cetl::pmr::function`.

### DIFF
--- a/.github/workflows/cetlvast.yml
+++ b/.github/workflows/cetlvast.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Cache ext modules
       id: cetlvast-ext
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cetlvast-ext-cache
       with:
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Cache ext modules
       id: cetlvast-ext
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cetlvast-ext-cache
       with:
@@ -136,7 +136,7 @@ jobs:
 
     - name: Cache ext modules
       id: cetlvast-ext
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cetlvast-ext-cache
       with:

--- a/cetlvast/cmake/compiler_flag_sets/default.cmake
+++ b/cetlvast/cmake/compiler_flag_sets/default.cmake
@@ -53,6 +53,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "Release build. Setting optimization flags.")
     list(APPEND C_FLAG_SET
                 "-O1"
+                "-fno-delete-null-pointer-checks"  # https://github.com/OpenCyphal-Garage/libcyphal/pull/347#discussion_r1572254288
     )
 else()
 

--- a/cetlvast/include/cetlvast/memory_resource_mock.hpp
+++ b/cetlvast/include/cetlvast/memory_resource_mock.hpp
@@ -1,0 +1,61 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef CETLVAST_MEMORY_RESOURCE_MOCK_HPP_INCLUDED
+#define CETLVAST_MEMORY_RESOURCE_MOCK_HPP_INCLUDED
+
+#include "cetl/pf17/cetlpf.hpp"
+#include "cetl/pmr/memory.hpp"
+
+#include <gmock/gmock.h>
+
+class MemoryResourceMock : public cetl::pmr::memory_resource
+{
+public:
+    cetl::pmr::memory_resource* resource() noexcept
+    {
+        return this;
+    }
+
+    MOCK_METHOD(void*, do_allocate, (std::size_t, std::size_t), (override));
+    MOCK_METHOD(void, do_deallocate, (void*, std::size_t, std::size_t));
+    // NOLINTNEXTLINE(bugprone-exception-escape)
+    MOCK_METHOD(bool, do_is_equal, (const memory_resource&), (const, noexcept, override));
+
+#if (__cplusplus < CETL_CPP_STANDARD_17)
+    // NOLINTNEXTLINE(bugprone-exception-escape)
+    MOCK_METHOD(std::size_t, do_max_size, (), (const, noexcept, override));
+    MOCK_METHOD(void*, do_reallocate, (void*, std::size_t, std::size_t, std::size_t), (override));
+#endif
+
+    void redirectExpectedCallsTo(cetl::pmr::memory_resource& mr)
+    {
+        using ::testing::_;
+
+        EXPECT_CALL(*this, do_allocate(_, _))
+            .WillRepeatedly([&mr](std::size_t size_bytes, std::size_t alignment) -> void* {
+                return mr.allocate(size_bytes, alignment);
+            });
+        EXPECT_CALL(*this, do_deallocate(_, _, _))
+            .WillRepeatedly([&mr](void* p, std::size_t size_bytes, std::size_t alignment) {
+                mr.deallocate(p, size_bytes, alignment);
+            });
+        EXPECT_CALL(*this, do_is_equal(_)).WillRepeatedly([&mr](const memory_resource& rhs) {
+            return mr.is_equal(rhs);
+        });
+
+#if (__cplusplus < CETL_CPP_STANDARD_17)
+        EXPECT_CALL(*this, do_max_size()).WillRepeatedly([&mr]() { return mr.max_size(); });
+        EXPECT_CALL(*this, do_reallocate(_, _, _, _))
+            .WillRepeatedly(
+                [&mr](void* ptr, std::size_t old_size_bytes, std::size_t new_size_bytes, std::size_t alignment) {
+                    return mr.reallocate(ptr, old_size_bytes, new_size_bytes, alignment);
+                });
+#endif
+    }
+
+};  // MemoryResourceMock
+
+#endif  // CETLVAST_MEMORY_RESOURCE_MOCK_HPP_INCLUDED

--- a/cetlvast/include/cetlvast/memory_resource_mock.hpp
+++ b/cetlvast/include/cetlvast/memory_resource_mock.hpp
@@ -11,6 +11,9 @@
 
 #include <gmock/gmock.h>
 
+namespace cetlvast
+{
+
 class MemoryResourceMock : public cetl::pmr::memory_resource
 {
 public:
@@ -57,5 +60,7 @@ public:
     }
 
 };  // MemoryResourceMock
+
+} // namespace cetlvast
 
 #endif  // CETLVAST_MEMORY_RESOURCE_MOCK_HPP_INCLUDED

--- a/cetlvast/include/cetlvast/tracking_memory_resource.hpp
+++ b/cetlvast/include/cetlvast/tracking_memory_resource.hpp
@@ -12,6 +12,9 @@
 #include <ostream>
 #include <vector>
 
+namespace cetlvast
+{
+
 class TrackingMemoryResource final : public cetl::pmr::memory_resource
 {
 public:
@@ -85,5 +88,7 @@ private:
     }
 
 };  // TrackingMemoryResource
+
+} // namespace cetlvast
 
 #endif  // CETLVAST_TRACKING_MEMORY_RESOURCE_HPP_INCLUDED

--- a/cetlvast/include/cetlvast/tracking_memory_resource.hpp
+++ b/cetlvast/include/cetlvast/tracking_memory_resource.hpp
@@ -1,0 +1,89 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef CETLVAST_TRACKING_MEMORY_RESOURCE_HPP_INCLUDED
+#define CETLVAST_TRACKING_MEMORY_RESOURCE_HPP_INCLUDED
+
+#include "cetl/pf17/cetlpf.hpp"
+#include "cetl/pmr/memory.hpp"
+
+#include <ostream>
+#include <vector>
+
+class TrackingMemoryResource final : public cetl::pmr::memory_resource
+{
+public:
+    struct Allocation final
+    {
+        std::size_t size;
+        void*       pointer;
+
+        friend void PrintTo(const Allocation& alloc, std::ostream* os)
+        {
+            *os << "\n{ptr=0x" << std::hex << alloc.pointer << ", size=" << std::dec << alloc.size << "}";
+        }
+    };
+
+    // NOLINTBEGIN
+    std::vector<Allocation> allocations{};
+    std::size_t             total_allocated_bytes   = 0;
+    std::size_t             total_deallocated_bytes = 0;
+    // NOLINTEND
+
+private:
+    // MARK: cetl::pmr::memory_resource
+
+    void* do_allocate(std::size_t size_bytes, std::size_t alignment) override
+    {
+        if (alignment > alignof(std::max_align_t))
+        {
+#if defined(__cpp_exceptions)
+            throw std::bad_alloc();
+#endif
+            return nullptr;
+        }
+
+        auto ptr = std::malloc(size_bytes);
+
+        total_allocated_bytes += size_bytes;
+        allocations.push_back({size_bytes, ptr});
+
+        return ptr;
+    }
+
+    void do_deallocate(void* ptr, std::size_t size_bytes, std::size_t) override
+    {
+        auto prev_alloc = std::find_if(allocations.cbegin(), allocations.cend(), [ptr](const auto& alloc) {
+            return alloc.pointer == ptr;
+        });
+        if (prev_alloc != allocations.cend())
+        {
+            allocations.erase(prev_alloc);
+        }
+        total_deallocated_bytes += size_bytes;
+
+        std::free(ptr);
+    }
+
+#if (__cplusplus < CETL_CPP_STANDARD_17)
+
+    void* do_reallocate(void* ptr, std::size_t old_size_bytes, std::size_t new_size_bytes, std::size_t) override
+    {
+        total_allocated_bytes -= old_size_bytes;
+        total_allocated_bytes += new_size_bytes;
+
+        return std::realloc(ptr, new_size_bytes);
+    }
+
+#endif
+
+    bool do_is_equal(const memory_resource& rhs) const noexcept override
+    {
+        return (&rhs == this);
+    }
+
+};  // TrackingMemoryResource
+
+#endif  // CETLVAST_TRACKING_MEMORY_RESOURCE_HPP_INCLUDED

--- a/cetlvast/suites/compile/test_unbounded_variant_footprint_get_const.cpp
+++ b/cetlvast/suites/compile/test_unbounded_variant_footprint_get_const.cpp
@@ -29,7 +29,7 @@ int main()
 
 #ifndef CETLVAST_COMPILETEST_PRECHECK
 
-    // Verify at `cetl::detail::base_storage::get_ptr const`
+    // Verify at `cetl::detail::base_storage::check_footprint` (called from `base_access::get_ptr() const`).
     // ```
     // static_assert(sizeof(ValueType) <= Footprint,
     //               "Cannot contain the requested type since the footprint is too small");

--- a/cetlvast/suites/compile/test_unbounded_variant_footprint_get_non_const.cpp
+++ b/cetlvast/suites/compile/test_unbounded_variant_footprint_get_non_const.cpp
@@ -29,7 +29,7 @@ int main()
 
 #ifndef CETLVAST_COMPILETEST_PRECHECK
 
-    // Verify at `cetl::detail::base_storage::get_ptr`
+    // Verify at `cetl::detail::base_storage::check_footprint` (called from `base_access::get_ptr()`).
     // ```
     // static_assert(sizeof(ValueType) <= Footprint,
     //               "Cannot contain the requested type since the footprint is too small");

--- a/cetlvast/suites/compile/test_unbounded_variant_footprint_set.cpp
+++ b/cetlvast/suites/compile/test_unbounded_variant_footprint_set.cpp
@@ -31,7 +31,7 @@ int main()
 
     // Verify at `cetl::detail::base_storage::make_handlers`
     // ```
-    // static_assert(sizeof(Tp) <= Footprint, "Enlarge the footprint");
+    // static_assert(sizeof(Tp) <= Footprint || IsPmr, "Enlarge the footprint");
     // ```
     test = static_cast<uint16_t>(1);
 

--- a/cetlvast/suites/compile/test_unbounded_variant_footprint_set.cpp
+++ b/cetlvast/suites/compile/test_unbounded_variant_footprint_set.cpp
@@ -29,9 +29,9 @@ int main()
 
 #ifndef CETLVAST_COMPILETEST_PRECHECK
 
-    // Verify at `cetl::detail::base_storage::make_handlers`
+    // Verify at `cetl::detail::base_storage::check_footprint` (called from `base_access::make_handlers()`).
     // ```
-    // static_assert(sizeof(Tp) <= Footprint || IsPmr, "Enlarge the footprint");
+    // static_assert(sizeof(Tp) <= Footprint, "Enlarge the footprint");
     // ```
     test = static_cast<uint16_t>(1);
 

--- a/cetlvast/suites/compile/test_unbounded_variant_zero_footprint_non_pmr.cpp
+++ b/cetlvast/suites/compile/test_unbounded_variant_zero_footprint_non_pmr.cpp
@@ -1,0 +1,27 @@
+/// @file
+/// Compile test that ensures it's impossible to use non-PMR `unbounded_variant` with zero footprint.
+///
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+///
+
+#include "cetl/unbounded_variant.hpp"
+
+#include <cstdint>
+
+int main()
+{
+#ifndef CETLVAST_COMPILETEST_PRECHECK
+
+    cetl::unbounded_variant<0> test{};
+
+#else
+
+    cetl::unbounded_variant<1> test{};
+
+#endif
+
+    return 0;
+}

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -60,9 +60,6 @@ public:
 
 protected:
     ~IIdentifiable() = default;
-
-private:
-    //std::array<char, 16> padding_;
 };
 
 class MyObjectBase
@@ -101,7 +98,7 @@ public:
         free(name_);
     }
 
-    // MARK: - INameable
+    // MARK: INameable
 
     std::string name() const override
     {
@@ -115,14 +112,14 @@ public:
         }
     }
 
-    // MARK: - IIdentifiable
+    // MARK: IIdentifiable
 
     std::uint32_t id() const override
     {
         return id_;
     }
 
-    // MARK: - IDescribable
+    // MARK: IDescribable
 
     std::string description() const override
     {
@@ -238,7 +235,7 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
 
     cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::new_delete_resource()};
 
-    auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj1", 4U);
+    auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj0", 4U);
 
     auto obj1 = cetl::pmr::InterfaceFactory::make_unique<IIdentifiable>(alloc, "obj1", 4U);
     {

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -134,7 +134,7 @@ class example_07_polymorphic_alloc_deleter : public testing::Test
 {
 protected:
     template <typename Interface>
-    using InterfacePtr = cetl::pmr::InterfacePtr<Interface>;
+    using InterfacePtr = cetl::pmr::InterfacePtr<Interface, cetl::pmr::memory_resource>;
 
     void SetUp() override
     {

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -84,10 +84,9 @@ class MyObject final : private MyObjectBase, public IIdentifiable, public IDescr
 {
 public:
     MyObject(const char* name, std::size_t name_length)
-        : name_{nullptr}
+        : name_{static_cast<char*>(malloc(name_length + 1))}
     {
-        name_ = static_cast<char*>(malloc(name_length + 1));
-        strncpy(name_, name, name_length);
+        strncpy(name_, name, name_length + 1);
         name_[name_length] = '\0';
     }
 

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -239,9 +239,12 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
 
     cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::new_delete_resource()};
 
+    auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj1", 4U);
+
     auto obj1 = cetl::pmr::InterfaceFactory::make_unique<IIdentifiable>(alloc, "obj1", 4U);
     {
         std::cout << "Obj1 id  : " << obj1->id() << std::endl;
+        obj1.reset();
         std::cout << std::endl;
     }
     auto obj2 = cetl::pmr::InterfaceFactory::make_unique<IDescribable>(alloc, "obj2", 4U);
@@ -251,8 +254,6 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
 
         auto obj2_nameable = InterfacePtr<INameable>{std::move(obj2)};
         std::cout << "Obj2 name_b  : " << obj2_nameable->name() << std::endl;
-        obj2_nameable.reset();
-        std::cout << std::endl;
     }
     auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INameable>(alloc, "obj3", 4U);
     {

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -134,7 +134,7 @@ class example_07_polymorphic_alloc_deleter : public testing::Test
 {
 protected:
     template <typename Interface>
-    using InterfacePtr = cetl::pmr::InterfacePtr<Interface, cetl::pmr::memory_resource>;
+    using InterfacePtr = cetl::pmr::InterfacePtr<Interface>;
 
     void SetUp() override
     {
@@ -253,8 +253,10 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
         std::cout << "Obj2 desc  : " << obj2->describe() << std::endl;
         std::cout << "Obj2 name_a  : " << obj2->name() << std::endl;
 
-        auto obj2_named = InterfacePtr<INamed>{std::move(obj2)};
-        std::cout << "Obj2 name_b  : " << obj2_named->name() << std::endl;
+        // Such interface ptr upcasting currently is not supported.
+        //
+        //    auto obj2_named = InterfacePtr<INamed>{std::move(obj2)};
+        //    std::cout << "Obj2 name_b  : " << obj2_named->name() << std::endl;
     }
 
     auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INamed>(alloc, "obj3", 4U);

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -241,13 +241,13 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
     // Commented b/c of current limitation of our `cetl::pmr::function`.
     // Probably PMR support is needed at `cetl::unbounded_variant` (which we use inside the `function`),
     // so that it will be possible to nest one deleter inside another one.
-    /*
     auto obj1 = cetl::pmr::InterfaceFactory::make_unique<IIdentifiable>(alloc, "obj1", 4U);
     {
         std::cout << "Obj1 id  : " << obj1->id() << std::endl;
         obj1.reset();
         std::cout << std::endl;
     }
+
     auto obj2 = cetl::pmr::InterfaceFactory::make_unique<IDescribable>(alloc, "obj2", 4U);
     {
         std::cout << "Obj2 desc  : " << obj2->describe() << std::endl;
@@ -256,11 +256,12 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
         auto obj2_named = InterfacePtr<INamed>{std::move(obj2)};
         std::cout << "Obj2 name_b  : " << obj2_named->name() << std::endl;
     }
+
     auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INamed>(alloc, "obj3", 4U);
     {
         std::cout << "Obj3 name  : " << obj3->name() << std::endl;
         std::cout << std::endl;
     }
-    */
+
     //![example_usage_2]
 }

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -9,43 +9,102 @@
 /// cSpell: words emplacer
 
 #include "cetl/pf17/cetlpf.hpp"
+#include "cetl/pmr/interface_ptr.hpp"
 #include "cetl/pmr/memory.hpp"
 
 #include <unordered_map>
 #include <iostream>
-#include <string.h>
 
 #include <gtest/gtest.h>
 
+class INameable
+{
+public:
+    INameable()                                     = default;
+    INameable(const INameable&)                     = delete;
+    INameable(INameable&& rhs) noexcept             = delete;
+    INameable& operator=(INameable&&)               = delete;
+    INameable& operator=(const INameable&) noexcept = delete;
 
-class MyObject final
+    virtual std::string name() const = 0;
+
+protected:
+    ~INameable() = default;
+};
+
+class IDescribable : public INameable
+{
+public:
+    IDescribable()                                     = default;
+    IDescribable(const IDescribable&)                     = delete;
+    IDescribable(IDescribable&& rhs) noexcept             = delete;
+    IDescribable& operator=(IDescribable&&)               = delete;
+    IDescribable& operator=(const IDescribable&) noexcept = delete;
+
+    virtual std::string description() const = 0;
+
+protected:
+    ~IDescribable() = default;
+};
+
+class IIdentifiable
+{
+public:
+    IIdentifiable()                                         = default;
+    IIdentifiable(const IIdentifiable&)                     = delete;
+    IIdentifiable(IIdentifiable&& rhs) noexcept             = delete;
+    IIdentifiable& operator=(IIdentifiable&&)               = delete;
+    IIdentifiable& operator=(const IIdentifiable&) noexcept = delete;
+
+    virtual std::uint32_t id() const = 0;
+
+protected:
+    ~IIdentifiable() = default;
+
+private:
+    //std::array<char, 16> padding_;
+};
+
+class MyObjectBase
+{
+public:
+    MyObjectBase()
+        : id_{counter_++}
+    {
+    }
+
+protected:
+    const std::uint32_t  id_;
+    static std::uint32_t counter_;
+    friend class example_07_polymorphic_alloc_deleter;
+};
+std::uint32_t MyObjectBase::counter_ = 0;
+
+class MyObject final : private MyObjectBase, public IIdentifiable, public IDescribable
 {
 public:
     MyObject(const char* name, std::size_t name_length)
-        : name_(nullptr)
+        : name_{nullptr}
     {
         name_ = static_cast<char*>(malloc(name_length + 1));
         strncpy(name_, name, name_length);
         name_[name_length] = '\0';
     }
 
-    MyObject(const MyObject&)            = delete;
-    MyObject& operator=(const MyObject&) = delete;
-    MyObject& operator=(MyObject&&)      = delete;
-
-    MyObject(MyObject&& rhs) noexcept
-        : name_(rhs.name_)
-    {
-        rhs.name_ = nullptr;
-    }
+    MyObject(const MyObject&)                = delete;
+    MyObject(MyObject&& rhs) noexcept        = delete;
+    MyObject& operator=(const MyObject&)     = delete;
+    MyObject& operator=(MyObject&&) noexcept = delete;
 
     ~MyObject()
     {
-        std::cout << "MyObject destructor called : " << name_ << std::endl;
+        std::cout << "~MyObject(name='" << name_ << "', id=" << id_ << ")" << std::endl;
         free(name_);
     }
 
-    std::string name() const
+    // MARK: - INameable
+
+    std::string name() const override
     {
         if (name_ == nullptr)
         {
@@ -57,18 +116,44 @@ public:
         }
     }
 
+    // MARK: - IIdentifiable
+
+    std::uint32_t id() const override
+    {
+        return id_;
+    }
+
+    // MARK: - IDescribable
+
+    std::string description() const override
+    {
+        return name() + " is a MyObject instance.";
+    }
+
 private:
     char* name_;
 };
 
-TEST(example_07_polymorphic_alloc_deleter, example_usage_0)
+class example_07_polymorphic_alloc_deleter : public testing::Test
+{
+protected:
+    template <typename Interface>
+    using InterfacePtr = cetl::pmr::InterfacePtr<Interface>;
+
+    void SetUp() override
+    {
+        MyObjectBase::counter_ = 0;
+    }
+};
+
+TEST_F(example_07_polymorphic_alloc_deleter, example_usage_0)
 {
     //![example_usage_0]
     // Let's say you wanted to store a bunch of objects in a container of some sort. You can use the
     // cetl::pmr::PolymorphicDeleter to help you build unique_ptr's like this:
 
     using MyAllocator = cetl::pmr::polymorphic_allocator<MyObject>;
-    using MyDeleter = cetl::pmr::PolymorphicDeleter<MyAllocator>;
+    using MyDeleter   = cetl::pmr::PolymorphicDeleter<MyAllocator>;
     MyAllocator alloc{cetl::pmr::new_delete_resource()};
 
     std::unordered_map<std::string, std::unique_ptr<MyObject, MyDeleter>> objects;
@@ -81,21 +166,21 @@ TEST(example_07_polymorphic_alloc_deleter, example_usage_0)
     std::unique_ptr<MyObject, MyDeleter> object_0{alloc.allocate(1), MyDeleter{alloc, 1}};
     if (nullptr != object_0)
     {
-        alloc.construct(object_0.get(), "object_0", 9U);
+        alloc.construct(object_0.get(), "object_0", 8U);
         objects.emplace(object_0->name(), std::move(object_0));
-    } // else, if we're here then exceptions are turned off, but deallocation is always null-safe.
+    }  // else, if we're here then exceptions are turned off, but deallocation is always null-safe.
 
     std::unique_ptr<MyObject, MyDeleter> object_1{alloc.allocate(1), MyDeleter{alloc, 1}};
     if (nullptr != object_1)
     {
-        alloc.construct(object_1.get(), "object_1", 9U);
+        alloc.construct(object_1.get(), "object_1", 8U);
         objects.emplace(object_1->name(), std::move(object_1));
     }
 
     std::unique_ptr<MyObject, MyDeleter> object_2{alloc.allocate(1), MyDeleter{alloc, 1}};
     if (nullptr != object_2)
     {
-        alloc.construct(object_2.get(), "object_2", 9U);
+        alloc.construct(object_2.get(), "object_2", 8U);
         objects.emplace(object_2->name(), std::move(object_2));
     }
 
@@ -109,7 +194,7 @@ TEST(example_07_polymorphic_alloc_deleter, example_usage_0)
     //![example_usage_0]
 }
 
-TEST(example_07_polymorphic_alloc_deleter, example_usage_1)
+TEST_F(example_07_polymorphic_alloc_deleter, example_usage_1)
 {
     //![example_usage_1]
     // By using the cetl::pmr::Factory, you can simplify the code from the previous example:
@@ -119,25 +204,24 @@ TEST(example_07_polymorphic_alloc_deleter, example_usage_1)
     std::unordered_map<std::string, cetl::pmr::Factory::unique_ptr_t<decltype(alloc)>> objects;
     objects.reserve(6);
 
-    auto object_0 = cetl::pmr::Factory::make_unique(alloc, "object_0", 9U);
+    auto object_0 = cetl::pmr::Factory::make_unique(alloc, "object_0", 8U);
     objects.emplace(object_0->name(), std::move(object_0));
 
-    auto object_1 = cetl::pmr::Factory::make_unique(alloc, "object_1", 9U);
+    auto object_1 = cetl::pmr::Factory::make_unique(alloc, "object_1", 8U);
     objects.emplace(object_1->name(), std::move(object_1));
 
-    auto object_2 = cetl::pmr::Factory::make_unique(alloc, "object_2", 9U);
+    auto object_2 = cetl::pmr::Factory::make_unique(alloc, "object_2", 8U);
     objects.emplace(object_2->name(), std::move(object_2));
 
     // or even simpler:
-    auto emplacer = [&objects, &alloc](const char* name, std::size_t name_length)
-    {
+    auto emplacer = [&objects, &alloc](const char* name, std::size_t name_length) {
         auto object = cetl::pmr::Factory::make_unique(alloc, name, name_length);
         objects.emplace(object->name(), std::move(object));
     };
 
-    emplacer("object_3", 9U);
-    emplacer("object_4", 9U);
-    emplacer("object_5", 9U);
+    emplacer("object_3", 8U);
+    emplacer("object_4", 8U);
+    emplacer("object_5", 8U);
 
     for (const auto& pair : objects)
     {
@@ -147,4 +231,34 @@ TEST(example_07_polymorphic_alloc_deleter, example_usage_1)
     // the objects will be deconstructed using the correct allocator.
 
     //![example_usage_1]
+}
+
+TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
+{
+    //![example_usage_2]
+
+    cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::new_delete_resource()};
+
+    auto obj1 = cetl::pmr::InterfaceFactory::make_unique<IIdentifiable>(alloc, "obj1", 4U);
+    {
+        std::cout << "Obj1 id  : " << obj1->id() << std::endl;
+        std::cout << std::endl;
+    }
+    auto obj2 = cetl::pmr::InterfaceFactory::make_unique<IDescribable>(alloc, "obj2", 4U);
+    {
+        std::cout << "Obj2 desc  : " << obj2->description() << std::endl;
+        std::cout << "Obj2 name_a  : " << obj2->name() << std::endl;
+
+        auto obj2_nameable = InterfacePtr<INameable>{std::move(obj2)};
+        std::cout << "Obj2 name_b  : " << obj2_nameable->name() << std::endl;
+        obj2_nameable.reset();
+        std::cout << std::endl;
+    }
+    auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INameable>(alloc, "obj3", 4U);
+    {
+        std::cout << "Obj3 name  : " << obj3->name() << std::endl;
+        std::cout << std::endl;
+    }
+
+    //![example_usage_2]
 }

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -237,7 +237,11 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
 
     auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj0", 4U);
     std::cout << "Obj0 id  : " << obj0->id() << std::endl;
-/*
+
+    // Commented b/c of current limitation of our `cetl::pmr::function`.
+    // Probably PMR support is needed at `cetl::unbounded_variant` (which we use inside the `function`),
+    // so that it will be possible to nest one deleter inside another one.
+    /*
     auto obj1 = cetl::pmr::InterfaceFactory::make_unique<IIdentifiable>(alloc, "obj1", 4U);
     {
         std::cout << "Obj1 id  : " << obj1->id() << std::endl;
@@ -257,6 +261,6 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
         std::cout << "Obj3 name  : " << obj3->name() << std::endl;
         std::cout << std::endl;
     }
-*/
+    */
     //![example_usage_2]
 }

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -17,22 +17,22 @@
 
 #include <gtest/gtest.h>
 
-class INameable
+class INamed
 {
 public:
-    INameable()                                     = default;
-    INameable(const INameable&)                     = delete;
-    INameable(INameable&& rhs) noexcept             = delete;
-    INameable& operator=(INameable&&)               = delete;
-    INameable& operator=(const INameable&) noexcept = delete;
+    INamed()                                     = default;
+    INamed(const INamed&)                     = delete;
+    INamed(INamed&& rhs) noexcept             = delete;
+    INamed& operator=(INamed&&)               = delete;
+    INamed& operator=(const INamed&) noexcept = delete;
 
     virtual std::string name() const = 0;
 
 protected:
-    ~INameable() = default;
+    ~INamed() = default;
 };
 
-class IDescribable : public INameable
+class IDescribable : public INamed
 {
 public:
     IDescribable()                                     = default;
@@ -41,7 +41,7 @@ public:
     IDescribable& operator=(IDescribable&&)               = delete;
     IDescribable& operator=(const IDescribable&) noexcept = delete;
 
-    virtual std::string description() const = 0;
+    virtual std::string describe() const = 0;
 
 protected:
     ~IDescribable() = default;
@@ -98,7 +98,7 @@ public:
         free(name_);
     }
 
-    // MARK: INameable
+    // MARK: INamed
 
     std::string name() const override
     {
@@ -121,7 +121,7 @@ public:
 
     // MARK: IDescribable
 
-    std::string description() const override
+    std::string describe() const override
     {
         return name() + " is a MyObject instance.";
     }
@@ -236,7 +236,8 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
     cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::new_delete_resource()};
 
     auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj0", 4U);
-
+    std::cout << "Obj0 id  : " << obj0->id() << std::endl;
+/*
     auto obj1 = cetl::pmr::InterfaceFactory::make_unique<IIdentifiable>(alloc, "obj1", 4U);
     {
         std::cout << "Obj1 id  : " << obj1->id() << std::endl;
@@ -245,17 +246,17 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
     }
     auto obj2 = cetl::pmr::InterfaceFactory::make_unique<IDescribable>(alloc, "obj2", 4U);
     {
-        std::cout << "Obj2 desc  : " << obj2->description() << std::endl;
+        std::cout << "Obj2 desc  : " << obj2->describe() << std::endl;
         std::cout << "Obj2 name_a  : " << obj2->name() << std::endl;
 
-        auto obj2_nameable = InterfacePtr<INameable>{std::move(obj2)};
-        std::cout << "Obj2 name_b  : " << obj2_nameable->name() << std::endl;
+        auto obj2_named = InterfacePtr<INameable>{std::move(obj2)};
+        std::cout << "Obj2 name_b  : " << obj2_named->name() << std::endl;
     }
     auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INameable>(alloc, "obj3", 4U);
     {
         std::cout << "Obj3 name  : " << obj3->name() << std::endl;
         std::cout << std::endl;
     }
-
+*/
     //![example_usage_2]
 }

--- a/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
+++ b/cetlvast/suites/docs/examples/example_07_polymorphic_alloc_deleter.cpp
@@ -20,7 +20,7 @@
 class INamed
 {
 public:
-    INamed()                                     = default;
+    INamed()                                  = default;
     INamed(const INamed&)                     = delete;
     INamed(INamed&& rhs) noexcept             = delete;
     INamed& operator=(INamed&&)               = delete;
@@ -35,7 +35,7 @@ protected:
 class IDescribable : public INamed
 {
 public:
-    IDescribable()                                     = default;
+    IDescribable()                                        = default;
     IDescribable(const IDescribable&)                     = delete;
     IDescribable(IDescribable&& rhs) noexcept             = delete;
     IDescribable& operator=(IDescribable&&)               = delete;
@@ -150,7 +150,7 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_0)
 
     using MyAllocator = cetl::pmr::polymorphic_allocator<MyObject>;
     using MyDeleter   = cetl::pmr::PolymorphicDeleter<MyAllocator>;
-    MyAllocator alloc{cetl::pmr::new_delete_resource()};
+    MyAllocator alloc{cetl::pmr::get_default_resource()};
 
     std::unordered_map<std::string, std::unique_ptr<MyObject, MyDeleter>> objects;
     objects.reserve(3);
@@ -195,7 +195,7 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_1)
     //![example_usage_1]
     // By using the cetl::pmr::Factory, you can simplify the code from the previous example:
 
-    cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::new_delete_resource()};
+    cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::get_default_resource()};
 
     std::unordered_map<std::string, cetl::pmr::Factory::unique_ptr_t<decltype(alloc)>> objects;
     objects.reserve(6);
@@ -233,7 +233,7 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
 {
     //![example_usage_2]
 
-    cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::new_delete_resource()};
+    cetl::pmr::polymorphic_allocator<MyObject> alloc{cetl::pmr::get_default_resource()};
 
     auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj0", 4U);
     std::cout << "Obj0 id  : " << obj0->id() << std::endl;
@@ -249,10 +249,10 @@ TEST_F(example_07_polymorphic_alloc_deleter, example_usage_2)
         std::cout << "Obj2 desc  : " << obj2->describe() << std::endl;
         std::cout << "Obj2 name_a  : " << obj2->name() << std::endl;
 
-        auto obj2_named = InterfacePtr<INameable>{std::move(obj2)};
+        auto obj2_named = InterfacePtr<INamed>{std::move(obj2)};
         std::cout << "Obj2 name_b  : " << obj2_named->name() << std::endl;
     }
-    auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INameable>(alloc, "obj3", 4U);
+    auto obj3 = cetl::pmr::InterfaceFactory::make_unique<INamed>(alloc, "obj3", 4U);
     {
         std::cout << "Obj3 name  : " << obj3->name() << std::endl;
         std::cout << std::endl;

--- a/cetlvast/suites/unittest/CMakeLists.txt
+++ b/cetlvast/suites/unittest/CMakeLists.txt
@@ -19,11 +19,11 @@ endif()
 #   We generate individual test binaires so we can record which test generated
 #   what coverage. We also allow test authors to generate coverage reports for
 #   just one test allowing for faster iteration.
-file(GLOB NATIVE_TESTS
+file(GLOB_RECURSE NATIVE_TESTS
     LIST_DIRECTORIES false
     CONFIGURE_DEPENDS
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    test_*.cpp
+    test_*.cpp **/test_*.cpp
 )
 
 set(ALL_TESTS_BUILD "")

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -61,26 +61,26 @@ TEST_F(TestPmrFunction, cpp_reference)
     // store the result of a call to std::bind
     function<void(), 24> f_display_31337 = std::bind(print_num, 31337);
     f_display_31337();
-/*
+
     // store a call to a member function
-    function<void(const Foo&, int), 24> f_add_display = &Foo::print_add;
+    //function<void(const Foo&, int), 24> f_add_display = &Foo::print_add;
     const Foo                           foo(314159);
-    f_add_display(foo, 1);
-    f_add_display(314159, 1);
+    //f_add_display(foo, 1);
+    //f_add_display(314159, 1);
 
     // store a call to a data member accessor
-    function<int(Foo const&), 0> f_num = &Foo::num_;
-    EXPECT_THAT(f_num(foo), 314159);
+    //function<int(Foo const&), 0> f_num = &Foo::num_;
+    //EXPECT_THAT(f_num(foo), 314159);
 
     // store a call to a member function and object
     using std::placeholders::_1;
-    function<void(int), 0> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
+    function<void(int), 64> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
     f_add_display2(2);
-
+/*
     // store a call to a member function and object ptr
     function<void(int), 0> f_add_display3 = std::bind(&Foo::print_add, &foo, _1);
     f_add_display3(3);
-*/
+
     // store a call to a function object
     function<void(int), 16> f_display_obj = PrintNum();
     f_display_obj(18);
@@ -96,6 +96,7 @@ TEST_F(TestPmrFunction, cpp_reference)
         std::cout << i << "! = " << factorial(i) << ";  ";
     }
     std::cout << '\n';
+*/
 }
 
 TEST_F(TestPmrFunction, ctor_1_default)

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -94,7 +94,7 @@ TEST_F(TestPmrFunction, cpp_reference)
 
     // store a call to a member function and object
     using std::placeholders::_1;
-    function<std::string(int), 64> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
+    function<std::string(int), 32> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
     f_add_display2(2);
 
     // store a call to a member function and object ptr
@@ -151,7 +151,7 @@ TEST_F(TestPmrFunction, ctor_3_copy)
 
 TEST_F(TestPmrFunction, ctor_4_move)
 {
-    using str_function = function<std::string(), 24>;
+    using str_function = function<std::string(), 16>;
 
     str_function fn{[]() { return print_num(123); }};
 
@@ -167,7 +167,7 @@ TEST_F(TestPmrFunction, ctor_4_move)
 
 TEST_F(TestPmrFunction, ctor_5_functor_lambda)
 {
-    using str_function = function<std::string(), 24>;
+    using str_function = function<std::string(), 16>;
 
     str_function fn{[]() { return print_num(123); }};
     EXPECT_THAT(!!fn, true);
@@ -176,7 +176,7 @@ TEST_F(TestPmrFunction, ctor_5_functor_lambda)
 
 TEST_F(TestPmrFunction, assign_1_copy)
 {
-    using str_function = function<std::string(), 24>;
+    using str_function = function<std::string(), 16>;
 
     const str_function fn1{[]() { return print_num(123); }};
     EXPECT_THAT(!!fn1, true);
@@ -189,7 +189,7 @@ TEST_F(TestPmrFunction, assign_1_copy)
 
 TEST_F(TestPmrFunction, assign_2_move)
 {
-    using str_function = function<std::string(), 24>;
+    using str_function = function<std::string(), 16>;
 
     str_function fn1{[]() { return print_num(123); }};
     EXPECT_THAT(!!fn1, true);
@@ -202,7 +202,7 @@ TEST_F(TestPmrFunction, assign_2_move)
 
 TEST_F(TestPmrFunction, assign_3_nullptr)
 {
-    using str_function = function<std::string(), 24>;
+    using str_function = function<std::string(), 16>;
     str_function fn{[]() { return print_num(123); }};
     EXPECT_THAT(!!fn, true);
 
@@ -212,11 +212,11 @@ TEST_F(TestPmrFunction, assign_3_nullptr)
 
 TEST_F(TestPmrFunction, assign_4_rv_functor)
 {
-    function<std::string(const std::string&), 24> f1;
+    function<std::string(const std::string&), 16> f1;
     f1 = [](const std::string& rhs) { return "A" + rhs; };
     EXPECT_THAT(f1("x"), "Ax");
 
-    function<std::string(const std::string&), 112> f2;
+    function<std::string(const std::string&), 96> f2;
     f2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
     EXPECT_THAT(f2("x"), "AxB");
 
@@ -229,14 +229,14 @@ TEST_F(TestPmrFunction, assign_4_rv_functor)
 
 TEST_F(TestPmrFunction, assign_4_lv_functor)
 {
-    function<std::string(const std::string&), 24> f1;
+    function<std::string(const std::string&), 16> f1;
     auto                                          l1 = [](const std::string& rhs) { return "A" + rhs; };
     f1                                               = l1;
     EXPECT_THAT(f1("x"), "Ax");
 
-    function<std::string(const std::string&), 80> f2;
-    auto                                          l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
-    f2                                               = l2;
+    function<std::string(const std::string&), 16> f2;
+    auto                                           l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
+    f2                                                = l2;
     EXPECT_THAT(f2("x"), "AxB");
 
     // Note: we copy assign different type of function (Footprint and IsPmr).
@@ -315,7 +315,6 @@ TEST_F(TestPmrFunction, pmr_ctor_5_lambda_custom_mr_)
 
 TEST_F(TestPmrFunction, pmr_ctor_memory_resource)
 {
-    // TODO: Remove `static_cast` when Callable constraint will be available.
     const function<void(), 0, true /*IsPmr*/> f1{get_mr()};
     EXPECT_THAT(!f1, Not(false));
     EXPECT_THAT(static_cast<bool>(f1), false);
@@ -411,13 +410,11 @@ TEST_F(TestPmrFunction, pmr_assign_4_rv_functor)
 {
     using str_function = function<std::string(const std::string&), 24, true /*IsPmr*/>;
 
-    // TODO: Remove `static_cast` when Callable constraint will be available.
     str_function f1{get_mr()};
     f1 = [](const std::string& rhs) { return "A" + rhs; };
     EXPECT_THAT(f1("x"), "Ax");
     EXPECT_THAT(f1.get_memory_resource(), get_mr());
 
-    // TODO: Remove `static_cast` when Callable constraint will be available.
     str_function f2{get_mr()};
     f2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
     EXPECT_THAT(f2("x"), "AxB");
@@ -435,14 +432,12 @@ TEST_F(TestPmrFunction, pmr_assign_4_lv_functor)
 {
     using str_function = function<std::string(const std::string&), 24, true /*IsPmr*/>;
 
-    // TODO: Remove `static_cast` when Callable constraint will be available.
     str_function f1{get_mr()};
     auto         l1 = [](const std::string& rhs) { return "A" + rhs; };
     f1              = l1;
     EXPECT_THAT(f1("x"), "Ax");
     EXPECT_THAT(f1.get_memory_resource(), get_mr());
 
-    // TODO: Remove `static_cast` when Callable constraint will be available.
     str_function f2{get_mr()};
     auto         l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
     f2              = l2;

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -1,0 +1,115 @@
+/// @file
+/// Unit tests for cetl/pmr/function.hpp
+///
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#include <cetl/pmr/function.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace
+{
+
+using cetl::pmr::function;
+
+using testing::Not;
+
+class TestPmrFunction : public testing::Test
+{
+protected:
+    static void print_num(int i)
+    {
+        std::cout << i << '\n';
+    }
+};
+
+TEST_F(TestPmrFunction, cpp_reference)
+{
+    struct Foo
+    {
+        Foo(int num)
+            : num_{num}
+        {
+        }
+        void print_add(int i) const
+        {
+            std::cout << num_ + i << '\n';
+        }
+        int num_;
+    };
+    struct PrintNum
+    {
+        void operator()(int i) const
+        {
+            std::cout << i << '\n';
+        }
+    };
+
+    // store a free function
+    function<void(int), 16> f_display = print_num;
+    f_display(-9);
+
+    // store a lambda
+    function<void(), 16> f_display_42 = []() { print_num(42); };
+    f_display_42();
+
+    // store the result of a call to std::bind
+    function<void(), 24> f_display_31337 = std::bind(print_num, 31337);
+    f_display_31337();
+/*
+    // store a call to a member function
+    function<void(const Foo&, int), 24> f_add_display = &Foo::print_add;
+    const Foo                           foo(314159);
+    f_add_display(foo, 1);
+    f_add_display(314159, 1);
+
+    // store a call to a data member accessor
+    function<int(Foo const&), 0> f_num = &Foo::num_;
+    EXPECT_THAT(f_num(foo), 314159);
+
+    // store a call to a member function and object
+    using std::placeholders::_1;
+    function<void(int), 0> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
+    f_add_display2(2);
+
+    // store a call to a member function and object ptr
+    function<void(int), 0> f_add_display3 = std::bind(&Foo::print_add, &foo, _1);
+    f_add_display3(3);
+*/
+    // store a call to a function object
+    function<void(int), 16> f_display_obj = PrintNum();
+    f_display_obj(18);
+
+    auto factorial = [](int n)
+    {
+        // store a lambda object to emulate "recursive lambda"; aware of extra overhead
+        function<int(int), 16> fac = [&](int _n) { return (_n < 2) ? 1 : _n * fac(_n - 1); };
+        return fac(n);
+    };
+    for (int i{5}; i != 8; ++i)
+    {
+        std::cout << i << "! = " << factorial(i) << ";  ";
+    }
+    std::cout << '\n';
+}
+
+TEST_F(TestPmrFunction, ctor_1_default)
+{
+    function<void(), 0> f1;
+    EXPECT_THAT(!f1, Not(false));
+    EXPECT_THAT(static_cast<bool>(f1), false);
+}
+
+TEST_F(TestPmrFunction, ctor_2_nullptr)
+{
+    function<void(), 0> f1{nullptr};
+    EXPECT_THAT(!f1, Not(false));
+    EXPECT_THAT(static_cast<bool>(f1), false);
+}
+
+}  // namespace

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -216,7 +216,7 @@ TEST_F(TestPmrFunction, assign_4_rv_functor)
     f1 = [](const std::string& rhs) { return "A" + rhs; };
     EXPECT_THAT(f1("x"), "Ax");
 
-    function<std::string(const std::string&), 96> f2;
+    function<std::string(const std::string&), 112> f2;
     f2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
     EXPECT_THAT(f2("x"), "AxB");
 

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -45,7 +45,7 @@ protected:
         return &mr_;
     }
 
-    TrackingMemoryResource mr_;
+    cetlvast::TrackingMemoryResource mr_;
 };
 
 TEST_F(TestPmrFunction, cpp_reference)

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -234,9 +234,9 @@ TEST_F(TestPmrFunction, assign_4_lv_functor)
     f1                                               = l1;
     EXPECT_THAT(f1("x"), "Ax");
 
-    function<std::string(const std::string&), 16> f2;
-    auto                                           l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
-    f2                                                = l2;
+    function<std::string(const std::string&), 96> f2;
+    auto                                          l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
+    f2                                               = l2;
     EXPECT_THAT(f2("x"), "AxB");
 
     // Note: we copy assign different type of function (Footprint and IsPmr).
@@ -245,6 +245,22 @@ TEST_F(TestPmrFunction, assign_4_lv_functor)
     EXPECT_THAT(!!f0, true);
     EXPECT_THAT(f0.get_memory_resource(), cetl::pmr::get_default_resource());
     EXPECT_THAT(f2("x"), "123");
+}
+
+TEST_F(TestPmrFunction, swap)
+{
+    using str_function = function<std::string(), 16>;
+
+    str_function fn1{[]() { return print_num(123); }};
+    str_function fn2{[]() { return print_num(456); }};
+
+    EXPECT_THAT(fn1(), "123");
+    EXPECT_THAT(fn2(), "456");
+
+    std::swap(fn1, fn2);
+
+    EXPECT_THAT(fn1(), "456");
+    EXPECT_THAT(fn2(), "123");
 }
 
 TEST_F(TestPmrFunction, pmr_ctor_1_default)

--- a/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_function.cpp
@@ -6,11 +6,13 @@
 /// Copyright Amazon.com Inc. or its affiliates.
 /// SPDX-License-Identifier: MIT
 
+#include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pmr/function.hpp>
+#include <cetlvast/tracking_memory_resource.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <iostream>
+#include <string>
 
 namespace
 {
@@ -18,14 +20,32 @@ namespace
 using cetl::pmr::function;
 
 using testing::Not;
+using testing::IsEmpty;
 
 class TestPmrFunction : public testing::Test
 {
 protected:
-    static void print_num(int i)
+    void SetUp() override {}
+
+    void TearDown() override
     {
-        std::cout << i << '\n';
+        EXPECT_THAT(mr_.allocations, IsEmpty());
+        EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        cetl::pmr::set_default_resource(nullptr);
     }
+
+    static std::string print_num(int i)
+    {
+        return testing::PrintToString(i);
+    }
+
+    cetl::pmr::memory_resource* get_mr() noexcept
+    {
+        return &mr_;
+    }
+
+    TrackingMemoryResource mr_;
 };
 
 TEST_F(TestPmrFunction, cpp_reference)
@@ -36,81 +56,405 @@ TEST_F(TestPmrFunction, cpp_reference)
             : num_{num}
         {
         }
-        void print_add(int i) const
+        std::string print_add(int i) const
         {
-            std::cout << num_ + i << '\n';
+            return print_num(num_ + i);
         }
         int num_;
     };
     struct PrintNum
     {
-        void operator()(int i) const
+        std::string operator()(int i) const
         {
-            std::cout << i << '\n';
+            return print_num(i);
         }
     };
 
     // store a free function
-    function<void(int), 16> f_display = print_num;
-    f_display(-9);
+    function<std::string(int), 16> f_display = print_num;
+    EXPECT_THAT(f_display(-9), "-9");
 
     // store a lambda
-    function<void(), 16> f_display_42 = []() { print_num(42); };
-    f_display_42();
+    function<std::string(), 16> f_display_42 = []() { return print_num(42); };
+    EXPECT_THAT(f_display_42(), "42");
 
     // store the result of a call to std::bind
-    function<void(), 24> f_display_31337 = std::bind(print_num, 31337);
-    f_display_31337();
+    function<std::string(), 24> f_display_31337 = std::bind(print_num, 31337);
+    EXPECT_THAT(f_display_31337(), "31337");
 
     // store a call to a member function
-    //function<void(const Foo&, int), 24> f_add_display = &Foo::print_add;
-    const Foo                           foo(314159);
-    //f_add_display(foo, 1);
-    //f_add_display(314159, 1);
+    // function<void(const Foo&, int), 24> f_add_display = &Foo::print_add;
+    const Foo foo(314159);
+    // f_add_display(foo, 1);
+    // f_add_display(314159, 1);
 
     // store a call to a data member accessor
-    //function<int(Foo const&), 0> f_num = &Foo::num_;
-    //EXPECT_THAT(f_num(foo), 314159);
+    // function<int(Foo const&), 0> f_num = &Foo::num_;
+    // EXPECT_THAT(f_num(foo), 314159);
 
     // store a call to a member function and object
     using std::placeholders::_1;
-    function<void(int), 64> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
+    function<std::string(int), 64> f_add_display2 = std::bind(&Foo::print_add, foo, _1);
     f_add_display2(2);
-/*
+
     // store a call to a member function and object ptr
-    function<void(int), 0> f_add_display3 = std::bind(&Foo::print_add, &foo, _1);
+    function<std::string(int), 32> f_add_display3 = std::bind(&Foo::print_add, &foo, _1);
     f_add_display3(3);
 
     // store a call to a function object
-    function<void(int), 16> f_display_obj = PrintNum();
-    f_display_obj(18);
+    function<std::string(int), 16> f_display_obj = PrintNum();
+    EXPECT_THAT(f_display_obj(18), "18");
 
-    auto factorial = [](int n)
-    {
+    auto factorial = [](int n) {
         // store a lambda object to emulate "recursive lambda"; aware of extra overhead
         function<int(int), 16> fac = [&](int _n) { return (_n < 2) ? 1 : _n * fac(_n - 1); };
         return fac(n);
     };
-    for (int i{5}; i != 8; ++i)
-    {
-        std::cout << i << "! = " << factorial(i) << ";  ";
-    }
-    std::cout << '\n';
-*/
+    EXPECT_THAT(factorial(1), 1);
+    EXPECT_THAT(factorial(2), 1 * 2);
+    EXPECT_THAT(factorial(3), 1 * 2 * 3);
+    EXPECT_THAT(factorial(4), 1 * 2 * 3 * 4);
+    EXPECT_THAT(factorial(5), 1 * 2 * 3 * 4 * 5);
+    EXPECT_THAT(factorial(6), 1 * 2 * 3 * 4 * 5 * 6);
+    EXPECT_THAT(factorial(7), 1 * 2 * 3 * 4 * 5 * 6 * 7);
 }
 
 TEST_F(TestPmrFunction, ctor_1_default)
 {
-    function<void(), 0> f1;
+    const function<void(), 0> f1{};
     EXPECT_THAT(!f1, Not(false));
     EXPECT_THAT(static_cast<bool>(f1), false);
 }
 
 TEST_F(TestPmrFunction, ctor_2_nullptr)
 {
-    function<void(), 0> f1{nullptr};
+    const function<void(), 0> f1{nullptr};
     EXPECT_THAT(!f1, Not(false));
     EXPECT_THAT(static_cast<bool>(f1), false);
+}
+
+TEST_F(TestPmrFunction, ctor_3_copy)
+{
+    using str_function = function<std::string(), 24>;
+
+    const str_function fn{std::bind(print_num, 123)};
+
+    str_function fn_copy{fn};
+    EXPECT_THAT(!!fn_copy, true);
+    EXPECT_THAT(static_cast<bool>(fn_copy), true);
+    EXPECT_THAT(fn_copy(), "123");
+
+    fn_copy = {};
+    const str_function fn_empty{fn_copy};
+    EXPECT_THAT(!!fn_empty, false);
+}
+
+TEST_F(TestPmrFunction, ctor_4_move)
+{
+    using str_function = function<std::string(), 24>;
+
+    str_function fn{[]() { return print_num(123); }};
+
+    str_function fn_moved{std::move(fn)};
+    EXPECT_THAT(!!fn_moved, true);
+    EXPECT_THAT(static_cast<bool>(fn_moved), true);
+    EXPECT_THAT(fn_moved(), "123");
+
+    fn_moved = {};
+    const str_function fn_empty{std::move(fn_moved)};
+    EXPECT_THAT(!!fn_empty, false);
+}
+
+TEST_F(TestPmrFunction, ctor_5_functor_lambda)
+{
+    using str_function = function<std::string(), 24>;
+
+    str_function fn{[]() { return print_num(123); }};
+    EXPECT_THAT(!!fn, true);
+    EXPECT_THAT(fn(), "123");
+}
+
+TEST_F(TestPmrFunction, assign_1_copy)
+{
+    using str_function = function<std::string(), 24>;
+
+    const str_function fn1{[]() { return print_num(123); }};
+    EXPECT_THAT(!!fn1, true);
+
+    const str_function fn2 = fn1;
+    EXPECT_THAT(!!fn1, true);
+    EXPECT_THAT(!!fn2, true);
+    EXPECT_THAT(fn2(), "123");
+}
+
+TEST_F(TestPmrFunction, assign_2_move)
+{
+    using str_function = function<std::string(), 24>;
+
+    str_function fn1{[]() { return print_num(123); }};
+    EXPECT_THAT(!!fn1, true);
+
+    const str_function fn2 = std::move(fn1);
+    EXPECT_THAT(!!fn1, false);
+    EXPECT_THAT(!!fn2, true);
+    EXPECT_THAT(fn2(), "123");
+}
+
+TEST_F(TestPmrFunction, assign_3_nullptr)
+{
+    using str_function = function<std::string(), 24>;
+    str_function fn{[]() { return print_num(123); }};
+    EXPECT_THAT(!!fn, true);
+
+    fn = nullptr;
+    EXPECT_THAT(!!fn, false);
+}
+
+TEST_F(TestPmrFunction, assign_4_rv_functor)
+{
+    function<std::string(const std::string&), 24> f1;
+    f1 = [](const std::string& rhs) { return "A" + rhs; };
+    EXPECT_THAT(f1("x"), "Ax");
+
+    function<std::string(const std::string&), 96> f2;
+    f2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
+    EXPECT_THAT(f2("x"), "AxB");
+
+    // Note: we move assign different type of function (Footprint and IsPmr).
+    function<std::string(const std::string&), 0, true /*IsPmr*/> f0{[](const std::string&) { return "123"; }};
+    f2 = std::move(f0);
+    EXPECT_THAT(!!f0, false);
+    EXPECT_THAT(f2("x"), "123");
+}
+
+TEST_F(TestPmrFunction, assign_4_lv_functor)
+{
+    function<std::string(const std::string&), 24> f1;
+    auto                                          l1 = [](const std::string& rhs) { return "A" + rhs; };
+    f1                                               = l1;
+    EXPECT_THAT(f1("x"), "Ax");
+
+    function<std::string(const std::string&), 80> f2;
+    auto                                          l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
+    f2                                               = l2;
+    EXPECT_THAT(f2("x"), "AxB");
+
+    // Note: we copy assign different type of function (Footprint and IsPmr).
+    const function<std::string(const std::string&), 0, true /*IsPmr*/> f0{[](const std::string&) { return "123"; }};
+    f2 = f0;
+    EXPECT_THAT(!!f0, true);
+    EXPECT_THAT(f0.get_memory_resource(), cetl::pmr::get_default_resource());
+    EXPECT_THAT(f2("x"), "123");
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_1_default)
+{
+    const function<void(), 0, true /*IsPmr*/> f1;
+    EXPECT_THAT(!f1, Not(false));
+    EXPECT_THAT(static_cast<bool>(f1), false);
+    EXPECT_THAT(f1.get_memory_resource(), cetl::pmr::get_default_resource());
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_2_nullptr)
+{
+    const function<void(), 0, true /*IsPmr*/> f1{nullptr};
+    EXPECT_THAT(!f1, Not(false));
+    EXPECT_THAT(static_cast<bool>(f1), false);
+    EXPECT_THAT(f1.get_memory_resource(), cetl::pmr::get_default_resource());
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_3_copy)
+{
+    using str_function = function<std::string(), 24, true /*IsPmr*/>;
+    const str_function fn{get_mr(), std::bind(print_num, 123)};
+
+    str_function fn_copy{fn};
+    EXPECT_THAT(!!fn_copy, true);
+    EXPECT_THAT(static_cast<bool>(fn_copy), true);
+    EXPECT_THAT(fn_copy.get_memory_resource(), get_mr());
+    EXPECT_THAT(fn_copy(), "123");
+
+    fn_copy = {};
+    const str_function fn_empty{fn_copy};
+    EXPECT_THAT(!!fn_empty, false);
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_4_move)
+{
+    using str_function = function<std::string(), 24, true /*IsPmr*/>;
+    str_function fn{get_mr(), []() { return print_num(123); }};
+
+    str_function fn_moved{std::move(fn)};
+    EXPECT_THAT(!!fn_moved, true);
+    EXPECT_THAT(static_cast<bool>(fn_moved), true);
+    EXPECT_THAT(fn_moved(), "123");
+    EXPECT_THAT(fn_moved.get_memory_resource(), get_mr());
+
+    fn_moved = {};
+    const str_function fn_empty{std::move(fn_moved)};
+    EXPECT_THAT(!!fn_empty, false);
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_5_lambda_default_mr_)
+{
+    using str_function = function<std::string(), 24, true /*IsPmr*/>;
+    str_function fn{[]() { return print_num(123); }};
+    EXPECT_THAT(!!fn, true);
+    EXPECT_THAT(fn(), "123");
+    EXPECT_THAT(fn.get_memory_resource(), cetl::pmr::get_default_resource());
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_5_lambda_custom_mr_)
+{
+    using str_function = function<std::string(), 0, true /*IsPmr*/>;
+    str_function fn{get_mr(), []() { return print_num(123); }};
+    EXPECT_THAT(!!fn, true);
+    EXPECT_THAT(fn(), "123");
+    EXPECT_THAT(fn.get_memory_resource(), get_mr());
+}
+
+TEST_F(TestPmrFunction, pmr_ctor_memory_resource)
+{
+    // TODO: Remove `static_cast` when Callable constraint will be available.
+    const function<void(), 0, true /*IsPmr*/> f1{get_mr()};
+    EXPECT_THAT(!f1, Not(false));
+    EXPECT_THAT(static_cast<bool>(f1), false);
+}
+
+TEST_F(TestPmrFunction, pmr_assign_1_copy_fit)
+{
+    using str_function = function<std::string(), 32, true /*IsPmr*/>;
+
+    const str_function fn1{get_mr(), []() { return print_num(123); }};
+    EXPECT_THAT(!!fn1, true);
+
+    str_function fn2 = fn1;
+    EXPECT_THAT(!!fn1, true);
+    EXPECT_THAT(fn1.get_memory_resource(), get_mr());
+    EXPECT_THAT(!!fn2, true);
+    EXPECT_THAT(fn2(), "123");
+    EXPECT_THAT(fn2.get_memory_resource(), get_mr());
+
+    fn2 = {};
+    EXPECT_THAT(!!fn1, true);
+    EXPECT_THAT(fn1.get_memory_resource(), get_mr());
+    EXPECT_THAT(!!fn2, false);
+}
+
+TEST_F(TestPmrFunction, pmr_assign_1_copy_nofit)
+{
+    using str_function = function<std::string(), 1, true /*IsPmr*/>;
+
+    const str_function fn1{get_mr(), []() { return print_num(123); }};
+    EXPECT_THAT(!!fn1, true);
+
+    str_function fn2 = fn1;
+    EXPECT_THAT(!!fn1, true);
+    EXPECT_THAT(fn1.get_memory_resource(), get_mr());
+    EXPECT_THAT(!!fn2, true);
+    EXPECT_THAT(fn2(), "123");
+    EXPECT_THAT(fn2.get_memory_resource(), get_mr());
+
+    fn2 = {};
+    EXPECT_THAT(!!fn1, true);
+    EXPECT_THAT(fn1.get_memory_resource(), get_mr());
+    EXPECT_THAT(!!fn2, false);
+    EXPECT_THAT(fn2.get_memory_resource(), get_mr());
+}
+
+TEST_F(TestPmrFunction, pmr_assign_2_move_fit)
+{
+    using str_function = function<std::string(), 32, true /*IsPmr*/>;
+
+    str_function fn1{get_mr(), []() { return print_num(123); }};
+    EXPECT_THAT(!!fn1, true);
+
+    str_function fn2 = std::move(fn1);
+    EXPECT_THAT(!!fn1, false);
+    EXPECT_THAT(!!fn2, true);
+    EXPECT_THAT(fn2(), "123");
+
+    fn2 = {};
+    EXPECT_THAT(!!fn2, false);
+    EXPECT_THAT(fn2.get_memory_resource(), get_mr());
+}
+
+TEST_F(TestPmrFunction, pmr_assign_2_move_nofit)
+{
+    using str_function = function<std::string(), 1, true /*IsPmr*/>;
+
+    str_function fn1{get_mr(), []() { return print_num(123); }};
+    EXPECT_THAT(!!fn1, true);
+
+    str_function fn2 = std::move(fn1);
+    EXPECT_THAT(!!fn1, false);
+    EXPECT_THAT(!!fn2, true);
+    EXPECT_THAT(fn2(), "123");
+
+    fn2 = {};
+    EXPECT_THAT(!!fn2, false);
+    EXPECT_THAT(fn2.get_memory_resource(), get_mr());
+}
+
+TEST_F(TestPmrFunction, pmr_assign_3_nullptr)
+{
+    using str_function = function<std::string(), 24, true /*IsPmr*/>;
+    str_function fn{get_mr(), []() { return print_num(123); }};
+    EXPECT_THAT(!!fn, true);
+
+    fn = nullptr;
+    EXPECT_THAT(!!fn, false);
+    EXPECT_THAT(fn.get_memory_resource(), get_mr());
+}
+
+TEST_F(TestPmrFunction, pmr_assign_4_rv_functor)
+{
+    using str_function = function<std::string(const std::string&), 24, true /*IsPmr*/>;
+
+    // TODO: Remove `static_cast` when Callable constraint will be available.
+    str_function f1{get_mr()};
+    f1 = [](const std::string& rhs) { return "A" + rhs; };
+    EXPECT_THAT(f1("x"), "Ax");
+    EXPECT_THAT(f1.get_memory_resource(), get_mr());
+
+    // TODO: Remove `static_cast` when Callable constraint will be available.
+    str_function f2{get_mr()};
+    f2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
+    EXPECT_THAT(f2("x"), "AxB");
+    EXPECT_THAT(f2.get_memory_resource(), get_mr());
+
+    // Note: we assign different type of function (different Footprint and IsPmr).
+    function<std::string(const std::string&), 16, false /*IsPmr*/> f0{[](const std::string&) { return "123"; }};
+    f2 = std::move(f0);
+    EXPECT_THAT(!!f0, false);
+    EXPECT_THAT(f2("x"), "123");
+    EXPECT_THAT(f2.get_memory_resource(), get_mr());
+}
+
+TEST_F(TestPmrFunction, pmr_assign_4_lv_functor)
+{
+    using str_function = function<std::string(const std::string&), 24, true /*IsPmr*/>;
+
+    // TODO: Remove `static_cast` when Callable constraint will be available.
+    str_function f1{get_mr()};
+    auto         l1 = [](const std::string& rhs) { return "A" + rhs; };
+    f1              = l1;
+    EXPECT_THAT(f1("x"), "Ax");
+    EXPECT_THAT(f1.get_memory_resource(), get_mr());
+
+    // TODO: Remove `static_cast` when Callable constraint will be available.
+    str_function f2{get_mr()};
+    auto         l2 = [f1](const std::string& rhs) { return f1(rhs) + "B"; };
+    f2              = l2;
+    EXPECT_THAT(f2("x"), "AxB");
+    EXPECT_THAT(f2.get_memory_resource(), get_mr());
+
+    // Note: we copy assign different type of function (Footprint and IsPmr).
+    const function<std::string(const std::string&), 16, false /*IsPmr*/> f0{[](const std::string&) { return "123"; }};
+    f2 = f0;
+    EXPECT_THAT(!!f0, true);
+    EXPECT_THAT(f2("x"), "123");
+    EXPECT_THAT(f2.get_memory_resource(), get_mr());
 }
 
 }  // namespace

--- a/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
@@ -1,0 +1,168 @@
+/// @file
+/// Unit tests for cetl/pmr/interface_ptr.hpp
+///
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#include <cetl/pmr/interface_ptr.hpp>
+#include <cetlvast/tracking_memory_resource.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace
+{
+
+using testing::IsEmpty;
+using testing::NotNull;
+
+class INamed
+{
+public:
+    INamed()                                  = default;
+    INamed(const INamed&)                     = delete;
+    INamed(INamed&& rhs) noexcept             = delete;
+    INamed& operator=(INamed&&)               = delete;
+    INamed& operator=(const INamed&) noexcept = delete;
+
+    virtual std::string name() const = 0;
+
+protected:
+    ~INamed() = default;
+};
+
+class IDescribable : public INamed
+{
+public:
+    IDescribable()                                        = default;
+    IDescribable(const IDescribable&)                     = delete;
+    IDescribable(IDescribable&& rhs) noexcept             = delete;
+    IDescribable& operator=(IDescribable&&)               = delete;
+    IDescribable& operator=(const IDescribable&) noexcept = delete;
+
+    virtual std::string describe() const = 0;
+
+protected:
+    ~IDescribable() = default;
+};
+
+class IIdentifiable
+{
+public:
+    IIdentifiable()                                         = default;
+    IIdentifiable(const IIdentifiable&)                     = delete;
+    IIdentifiable(IIdentifiable&& rhs) noexcept             = delete;
+    IIdentifiable& operator=(IIdentifiable&&)               = delete;
+    IIdentifiable& operator=(const IIdentifiable&) noexcept = delete;
+
+    virtual std::uint32_t id() const = 0;
+
+protected:
+    ~IIdentifiable() = default;
+};
+
+class MyObjectBase
+{
+public:
+    MyObjectBase()
+        : id_{counter_++}
+    {
+    }
+
+protected:
+    const std::uint32_t  id_;
+    static std::uint32_t counter_;
+    friend class TestPmrInterfacePtr;
+};
+std::uint32_t MyObjectBase::counter_ = 0;
+
+class MyObject final : private MyObjectBase, public IIdentifiable, public IDescribable
+{
+public:
+    MyObject(std::string name)
+        : name_{std::move(name)}
+    {
+    }
+
+    ~MyObject()                              = default;
+    MyObject(const MyObject&)                = delete;
+    MyObject(MyObject&& rhs) noexcept        = delete;
+    MyObject& operator=(const MyObject&)     = delete;
+    MyObject& operator=(MyObject&&) noexcept = delete;
+
+    // MARK: INamed
+
+    std::string name() const override
+    {
+        return name_;
+    }
+
+    // MARK: IIdentifiable
+
+    std::uint32_t id() const override
+    {
+        return id_;
+    }
+
+    // MARK: IDescribable
+
+    std::string describe() const override
+    {
+        return name() + " is a MyObject instance.";
+    }
+
+private:
+    std::string name_;
+};
+
+class TestPmrInterfacePtr : public testing::Test
+{
+protected:
+    template <typename Interface>
+    using InterfacePtr = cetl::pmr::InterfacePtr<Interface>;
+
+    void SetUp() override
+    {
+        MyObjectBase::counter_ = 0;
+    }
+
+    void TearDown() override
+    {
+        EXPECT_THAT(mr_.allocations, IsEmpty());
+        EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+    }
+
+    cetl::pmr::memory_resource* get_mr() noexcept
+    {
+        return &mr_;
+    }
+
+    TrackingMemoryResource mr_;
+};
+
+TEST_F(TestPmrInterfacePtr, make_unique_concrete)
+{
+    cetl::pmr::polymorphic_allocator<MyObject> alloc{get_mr()};
+
+    auto obj0 = cetl::pmr::InterfaceFactory::make_unique<MyObject>(alloc, "obj0");
+    EXPECT_THAT(obj0, NotNull());
+    EXPECT_THAT(obj0->name(), "obj0");
+    EXPECT_THAT(obj0->describe(), "obj0 is a MyObject instance.");
+}
+
+TEST_F(TestPmrInterfacePtr, make_unique_interface)
+{
+    cetl::pmr::polymorphic_allocator<MyObject> alloc{get_mr()};
+
+    auto obj0 = cetl::pmr::InterfaceFactory::make_unique<IDescribable>(alloc, "obj0");
+    EXPECT_THAT(obj0, NotNull());
+    EXPECT_THAT(obj0->name(), "obj0");
+    EXPECT_THAT(obj0->describe(), "obj0 is a MyObject instance.");
+
+    obj0.reset();
+}
+
+}  // namespace

--- a/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
@@ -16,6 +16,7 @@
 namespace
 {
 
+using testing::IsNull;
 using testing::IsEmpty;
 using testing::NotNull;
 
@@ -163,6 +164,24 @@ TEST_F(TestPmrInterfacePtr, make_unique_interface)
     EXPECT_THAT(obj0->describe(), "obj0 is a MyObject instance.");
 
     obj0.reset();
+}
+
+TEST_F(TestPmrInterfacePtr, up_cast_interface)
+{
+    cetl::pmr::polymorphic_allocator<MyObject> alloc{get_mr()};
+
+    auto obj0 = cetl::pmr::InterfaceFactory::make_unique<IDescribable>(alloc, "obj0");
+    EXPECT_THAT(obj0, NotNull());
+    EXPECT_THAT(obj0->name(), "obj0");
+    EXPECT_THAT(obj0->describe(), "obj0 is a MyObject instance.");
+
+    cetl::pmr::InterfacePtr<INamed> obj0_named{std::move(obj0)};
+
+    EXPECT_THAT(obj0, IsNull());
+    EXPECT_THAT(obj0_named, NotNull());
+    EXPECT_THAT(obj0_named->name(), "obj0");
+
+    obj0_named.reset();
 }
 
 }  // namespace

--- a/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
@@ -140,7 +140,7 @@ protected:
         return &mr_;
     }
 
-    TrackingMemoryResource mr_;
+    cetlvast::TrackingMemoryResource mr_;
 };
 
 TEST_F(TestPmrInterfacePtr, make_unique_concrete)

--- a/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
+++ b/cetlvast/suites/unittest/pmr/test_pmr_interface_ptr.cpp
@@ -122,8 +122,10 @@ private:
 class TestPmrInterfacePtr : public testing::Test
 {
 protected:
+    using pmr = cetl::pmr::memory_resource;
+
     template <typename Interface>
-    using InterfacePtr = cetl::pmr::InterfacePtr<Interface>;
+    using InterfacePtr = cetl::pmr::InterfacePtr<Interface, pmr>;
 
     void SetUp() override
     {
@@ -136,7 +138,7 @@ protected:
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
     }
 
-    cetl::pmr::memory_resource* get_mr() noexcept
+    pmr* get_mr() noexcept
     {
         return &mr_;
     }
@@ -175,7 +177,7 @@ TEST_F(TestPmrInterfacePtr, up_cast_interface)
     EXPECT_THAT(obj0->name(), "obj0");
     EXPECT_THAT(obj0->describe(), "obj0 is a MyObject instance.");
 
-    cetl::pmr::InterfacePtr<INamed> obj0_named{std::move(obj0)};
+    cetl::pmr::InterfacePtr<INamed, cetl::pmr::memory_resource> obj0_named{std::move(obj0)};
 
     EXPECT_THAT(obj0, IsNull());
     EXPECT_THAT(obj0_named, NotNull());

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -273,8 +273,6 @@ struct Empty
 class TestPmrUnboundedVariant : public testing::Test
 {
 protected:
-    void SetUp() override {}
-
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
@@ -1172,12 +1170,14 @@ TEST_F(TestPmrUnboundedVariant, pmr_ctor)
     EXPECT_THAT(dst.has_value(), false);
     EXPECT_THAT(dst.get_memory_resource(), get_mr());
 
-    dst = ub_var{'x'};
+    dst = ub_var{get_mr(), 'x'};
     EXPECT_THAT(dst.has_value(), true);
     EXPECT_THAT(get<char>(dst), 'x');
+    EXPECT_THAT(dst.get_memory_resource(), get_mr());
 
     dst = Empty{};
     EXPECT_THAT(dst.has_value(), true);
+    EXPECT_THAT(dst.get_memory_resource(), get_mr());
 
     ub_var dst2{};
     EXPECT_THAT(dst2.get_memory_resource(), cetl::pmr::get_default_resource());
@@ -1187,6 +1187,7 @@ TEST_F(TestPmrUnboundedVariant, pmr_ctor)
 
     dst2 = {};
     EXPECT_THAT(dst2.has_value(), false);
+    dst2.set_memory_resource(get_mr());
 
     dst2 = std::uint16_t{0x147};
     EXPECT_THAT(dst2.has_value(), true);
@@ -1210,9 +1211,13 @@ TEST_F(TestPmrUnboundedVariant, pmr_ctor)
     EXPECT_THAT(dst4.has_value(), false);
     EXPECT_THAT(dst4.get_memory_resource(), get_mr());
 
-    const ub_var dst5{std::move(dst4)};
+    ub_var dst5{std::move(dst4)};
     EXPECT_THAT(dst5.has_value(), false);
     EXPECT_THAT(dst5.get_memory_resource(), get_mr());
+
+    dst5 = {};
+    EXPECT_THAT(dst5.has_value(), false);
+    EXPECT_THAT(dst5.get_memory_resource(), cetl::pmr::get_default_resource());
 }
 
 }  // namespace

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -36,7 +36,6 @@ using testing::Return;
 using testing::IsNull;
 using testing::IsEmpty;
 using testing::NotNull;
-using testing::InSequence;
 using testing::StrictMock;
 
 using namespace std::string_literals;

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -265,6 +265,8 @@ private:
     using base = TestBase;
 };
 
+struct Empty {};
+
 /// TESTS -----------------------------------------------------------------------------------------------------------
 
 TEST(test_unbounded_variant, bad_unbounded_variant_access_ctor)
@@ -1099,14 +1101,19 @@ TEST(test_unbounded_variant, emplace_2_initializer_list)
 
 TEST(test_unbounded_variant, pmr_only_ctor)
 {
-    using ub_var = unbounded_variant<0, true, true, 1, true>;
+    using ub_var =
+        unbounded_variant<0 /*Footprint*/, true /*Copyable*/, true /*Movable*/, 1 /*Alignment*/, true /*IsPmr*/>;
 
-    auto mr = cetl::pmr::get_default_resource();
-
-    ub_var dst{mr};
+    ub_var dst{};
     EXPECT_THAT(dst.has_value(), false);
 
-    dst = ub_var{mr, 'x'};
+    dst = ub_var{'x'};
+
+    dst = Empty{};
+
+    ub_var dst2{};
+    dst2 = std::move(dst);
+    dst2 = {};
 }
 
 }  // namespace
@@ -1143,6 +1150,9 @@ constexpr type_id type_id_value<std::complex<double>> = {8};
 
 template <>
 constexpr type_id type_id_value<std::function<const char*()>> = {9};
+
+template <>
+constexpr type_id type_id_value<Empty> = {10};
 
 }  // namespace cetl
 

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -298,7 +298,7 @@ protected:
         return &mr_;
     }
 
-    TrackingMemoryResource mr_;
+    cetlvast::TrackingMemoryResource mr_;
 };
 
 /// TESTS -----------------------------------------------------------------------------------------------------------
@@ -1364,7 +1364,7 @@ TEST_F(TestPmrUnboundedVariant, pmr_with_footprint_move_value_when_out_of_memory
     side_effect_stats stats;
     auto              side_effects = stats.make_side_effect_fn();
 
-    StrictMock<MemoryResourceMock> mr_mock{};
+    StrictMock<cetlvast::MemoryResourceMock> mr_mock{};
 
     ub_var dst{mr_mock.resource()};
 
@@ -1419,7 +1419,7 @@ TEST_F(TestPmrUnboundedVariant, pmr_with_footprint_copy_value_when_out_of_memory
     side_effect_stats stats;
     auto              side_effects = stats.make_side_effect_fn();
 
-    StrictMock<MemoryResourceMock> mr_mock{};
+    StrictMock<cetlvast::MemoryResourceMock> mr_mock{};
 
     ub_var dst{mr_mock.resource()};
 
@@ -1481,7 +1481,7 @@ TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_move_value_when_out_of_memory)
     side_effect_stats stats;
     auto              side_effects = stats.make_side_effect_fn();
 
-    StrictMock<MemoryResourceMock> mr_mock{};
+    StrictMock<cetlvast::MemoryResourceMock> mr_mock{};
 
     ub_var dst{mr_mock.resource()};
 
@@ -1513,7 +1513,7 @@ TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_copy_value_when_out_of_memory)
     side_effect_stats stats;
     auto              side_effects = stats.make_side_effect_fn();
 
-    StrictMock<MemoryResourceMock> mr_mock{};
+    StrictMock<cetlvast::MemoryResourceMock> mr_mock{};
 
     EXPECT_CALL(mr_mock, do_allocate(sizeof(bool), Alignment))
         .WillOnce(

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -1108,12 +1108,53 @@ TEST(test_unbounded_variant, pmr_only_ctor)
     EXPECT_THAT(dst.has_value(), false);
 
     dst = ub_var{'x'};
+    EXPECT_THAT(dst.has_value(), true);
+    EXPECT_THAT(get<char>(dst), 'x');
 
     dst = Empty{};
+    EXPECT_THAT(dst.has_value(), true);
 
     ub_var dst2{};
     dst2 = std::move(dst);
+    EXPECT_THAT(dst2.has_value(), true);
+
     dst2 = {};
+    EXPECT_THAT(dst2.has_value(), false);
+}
+
+TEST(test_unbounded_variant, pmr_ctor)
+{
+    using ub_var =
+        unbounded_variant<2 /*Footprint*/, true /*Copyable*/, true /*Movable*/, 2 /*Alignment*/, true /*IsPmr*/>;
+
+    ub_var dst{};
+    EXPECT_THAT(dst.has_value(), false);
+
+    dst = ub_var{'x'};
+    EXPECT_THAT(dst.has_value(), true);
+    EXPECT_THAT(get<char>(dst), 'x');
+
+    dst = Empty{};
+    EXPECT_THAT(dst.has_value(), true);
+
+    ub_var dst2{};
+    dst2 = std::move(dst);
+    EXPECT_THAT(dst2.has_value(), true);
+
+    dst2 = {};
+    EXPECT_THAT(dst2.has_value(), false);
+
+    dst2 = std::uint16_t{0x147};
+    EXPECT_THAT(dst2.has_value(), true);
+    EXPECT_THAT(get<std::uint16_t>(dst2), 0x147);
+
+    dst2 = int{-1};
+    EXPECT_THAT(dst2.has_value(), true);
+    EXPECT_THAT(get<int>(dst2), -1);
+
+    dst2 = true;
+    EXPECT_THAT(dst2.has_value(), true);
+    EXPECT_THAT(get<bool>(dst2), true);
 }
 
 }  // namespace

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -1347,6 +1347,8 @@ TEST_F(TestPmrUnboundedVariant, pmr_with_footprint_copy_out_of_memory)
 
 TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_move_out_of_memory)
 {
+#if defined(__cpp_exceptions)
+
     const auto Alignment = alignof(std::max_align_t);
     using ub_var = unbounded_variant<0 /*Footprint*/, false /*Copyable*/, true /*Movable*/, Alignment, true /*IsPmr*/>;
 
@@ -1357,7 +1359,6 @@ TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_move_out_of_memory)
 
     ub_var dst{mr_mock.resource()};
 
-#if defined(__cpp_exceptions)
     // Emulate that there is no memory enough.
     {
         MyMovableOnly my_move_only{'X', side_effects};
@@ -1371,11 +1372,16 @@ TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_move_out_of_memory)
     }
     EXPECT_THAT(stats.constructs, stats.destructs);
     EXPECT_THAT(stats.ops, "@~");
+
+#else
+    GTEST_SKIP() << "Not applicable when exceptions are disabled.";
 #endif
 }
 
 TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_copy_out_of_memory)
 {
+#if defined(__cpp_exceptions)
+
     const auto Alignment = alignof(std::max_align_t);
     using ub_var = unbounded_variant<0 /*Footprint*/, true /*Copyable*/, false /*Movable*/, Alignment, true /*IsPmr*/>;
 
@@ -1386,7 +1392,6 @@ TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_copy_out_of_memory)
 
     ub_var dst{mr_mock.resource()};
 
-#if defined(__cpp_exceptions)
     // Emulate that there is no memory enough.
     {
         MyCopyableOnly my_copy_only{'X', side_effects};
@@ -1408,6 +1413,9 @@ TEST_F(TestPmrUnboundedVariant, pmr_no_footprint_copy_out_of_memory)
     }
     EXPECT_THAT(stats.constructs, stats.destructs);
     EXPECT_THAT(stats.ops, "@C~~");
+
+#else
+    GTEST_SKIP() << "Not applicable when exceptions are disabled.";
 #endif
 }
 

--- a/cetlvast/suites/unittest/test_unbounded_variant.cpp
+++ b/cetlvast/suites/unittest/test_unbounded_variant.cpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <string>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 // NOLINTBEGIN(*-use-after-move)
 
@@ -1094,6 +1095,18 @@ TEST(test_unbounded_variant, emplace_2_initializer_list)
     const auto test = get<TestType>(src);
     EXPECT_THAT(test.size_, 3);
     EXPECT_THAT(test.number_, 42);
+}
+
+TEST(test_unbounded_variant, pmr_only_ctor)
+{
+    using ub_var = unbounded_variant<0, true, true, 1, true>;
+
+    auto mr = cetl::pmr::get_default_resource();
+
+    ub_var dst{mr};
+    EXPECT_THAT(dst.has_value(), false);
+
+    dst = ub_var{mr, 'x'};
 }
 
 }  // namespace

--- a/include/cetl/pf17/cetlpf.hpp
+++ b/include/cetl/pf17/cetlpf.hpp
@@ -65,6 +65,10 @@ inline memory_resource* get_default_resource() noexcept
 {
     return std::pmr::get_default_resource();
 }
+inline memory_resource* set_default_resource(memory_resource* mr) noexcept
+{
+    return std::pmr::set_default_resource(mr);
+}
 }  // namespace pmr
 
 // utility
@@ -139,6 +143,10 @@ inline memory_resource* new_delete_resource() noexcept
 inline memory_resource* get_default_resource() noexcept
 {
     return cetl::pf17::pmr::get_default_resource();
+}
+inline memory_resource* set_default_resource(memory_resource* mr) noexcept
+{
+    return cetl::pf17::pmr::set_default_resource(mr);
 }
 }  // namespace pmr
 

--- a/include/cetl/pf17/cetlpf.hpp
+++ b/include/cetl/pf17/cetlpf.hpp
@@ -61,6 +61,10 @@ inline memory_resource* new_delete_resource() noexcept
 {
     return std::pmr::new_delete_resource();
 }
+inline memory_resource* get_default_resource() noexcept
+{
+    return std::pmr::get_default_resource();
+}
 }  // namespace pmr
 
 // utility
@@ -131,6 +135,10 @@ using polymorphic_allocator = cetl::pf17::pmr::polymorphic_allocator<T>;
 inline memory_resource* new_delete_resource() noexcept
 {
     return cetl::pf17::pmr::new_delete_resource();
+}
+inline memory_resource* get_default_resource() noexcept
+{
+    return cetl::pf17::pmr::get_default_resource();
 }
 }  // namespace pmr
 

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -185,7 +185,7 @@ public:
 
     explicit operator bool() const noexcept
     {
-        CETL_DEBUG_ASSERT(any_handler_.has_value() == (nullptr != handler_ptr), "");
+        CETL_DEBUG_ASSERT(any_handler_.has_value() == (nullptr != handler_ptr_), "");
 
         return any_handler_.has_value();
     }

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -171,8 +171,8 @@ public:
     {
         if (this != &other)
         {
-            any_handler_ = std::move(other.any_handler_);
-            handler_ptr_ = get_if<handler_t>(&any_handler_);
+            any_handler_       = std::move(other.any_handler_);
+            handler_ptr_       = get_if<handler_t>(&any_handler_);
             other.handler_ptr_ = nullptr;
         }
         return *this;

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -91,7 +91,7 @@ public:
 
     /// \brief Constructs an empty `function` object.
     ///
-    function(nullptr_t) noexcept {};
+    function(std::nullptr_t) noexcept {};
 
     /// \brief Constructs a `function` object with a copy of the content of `other`.
     ///

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -10,6 +10,7 @@
 #    include "cetl/cetl.hpp"
 #endif
 
+#include "cetl/pf17/cetlpf.hpp"
 #include "cetl/unbounded_variant.hpp"
 
 #include <cstddef>
@@ -21,7 +22,7 @@ namespace cetl
 namespace pmr
 {
 
-template <typename Signature, std::size_t Footprint>
+template <typename Signature, std::size_t Footprint, bool IsPmr = false>
 class function;
 
 /// Internal implementation details. Not supposed to be used directly by the users of the library.
@@ -53,8 +54,8 @@ template <typename Functor, typename Result, typename... Args>
 class functor_handler final : public rtti_helper<functor_handler_typeid_t, function_handler<Result, Args...>>
 {
 public:
-    explicit functor_handler(Functor&& functor)
-        : functor_{std::move(functor)}
+    explicit functor_handler(Functor functor)
+        : functor_{functor}
     {
     }
 
@@ -77,30 +78,22 @@ private:
 #endif
 }
 
-}  // namespace detail
-
+template <typename Signature, std::size_t Footprint, bool IsPmr>
+class function_base;
+//
 template <typename Result, typename... Args, std::size_t Footprint>
-class function<Result(Args...), Footprint>
+class function_base<Result(Args...), Footprint, false /*IsPmr*/>
 {
 public:
-    using result_type = Result;
+    function_base() noexcept                                 = default;
+    ~function_base()                                         = default;
+    function_base& operator=(const function_base& other)     = delete;
+    function_base& operator=(function_base&& other) noexcept = delete;
 
-    /// \brief Constructs an empty `function` object.
-    ///
-    constexpr function() noexcept = default;
-
-    /// \brief Constructs an empty `function` object.
-    ///
-    function(std::nullptr_t) noexcept {};
-
-    /// \brief Constructs a `function` object with a copy of the content of `other`.
-    ///
-    function(const function& other)
+    function_base(const function_base& other)
     {
-        if (static_cast<bool>(other))
+        if (other.any_handler_.has_value())
         {
-            CETL_DEBUG_ASSERT(other.any_handler_.has_value(), "");
-
             any_handler_ = other.any_handler_;
             handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
 
@@ -109,25 +102,22 @@ public:
         }
     }
 
-    /// \brief Constructs a `function` object with the content of `other` using move semantics.
-    ///
-    function(function&& other) noexcept
+    function_base(function_base&& other) noexcept
     {
-        if (static_cast<bool>(other))
+        if (other.any_handler_.has_value())
         {
-            CETL_DEBUG_ASSERT(other.any_handler_.has_value(), "");
-
-            any_handler_ = std::move(other.any_handler_);
-            handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+            any_handler_       = std::move(other.any_handler_);
+            handler_ptr_       = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+            other.handler_ptr_ = nullptr;
 
             CETL_DEBUG_ASSERT(any_handler_.has_value(), "");
             CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
         }
     }
 
-    // TODO: add Callable constraint
+    // TODO: Add Callable constraint;
     template <typename Functor>
-    function(Functor&& functor)
+    function_base(Functor&& functor)
         : any_handler_{detail::functor_handler<Functor, Result, Args...>{std::forward<Functor>(functor)}}
         , handler_ptr_{get_if<detail::function_handler<Result, Args...>>(&any_handler_)}
     {
@@ -135,7 +125,146 @@ public:
         CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
     }
 
-    ~function() = default;
+    // TODO: Add Callable constraint.
+    template <typename Functor>
+    function_base& operator=(Functor&& functor)
+    {
+        function_base tmp{std::forward<Functor>(functor)};
+        tmp.swap(*this);
+        return *this;
+    }
+
+    void swap(function_base& other) noexcept
+    {
+        any_handler_.swap(other.any_handler_);
+
+        handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+        other.handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&other.any_handler_);
+    }
+
+protected:
+    // TODO: Invest (later) into exploiting `Copyable` & `Movable` template params of our `unbounded_variant` -
+    // maybe we can make our `function_base` itself `Copyable` & `Movable` parametrized (aka `std::move_only_function`).
+    unbounded_variant<Footprint, true, true, alignof(std::max_align_t), false /*IsPmr*/> any_handler_;
+    detail::function_handler<Result, Args...>*                                           handler_ptr_{nullptr};
+};
+template <typename Result, typename... Args, std::size_t Footprint>
+class function_base<Result(Args...), Footprint, true /*IsPmr*/>
+{
+public:
+    function_base() noexcept
+        : any_handler_{get_default_resource()}
+    {
+    }
+
+    ~function_base()                                         = default;
+    function_base& operator=(const function_base& other)     = delete;
+    function_base& operator=(function_base&& other) noexcept = delete;
+
+    explicit function_base(memory_resource* const mem_res)
+        : any_handler_{mem_res}
+    {
+        CETL_DEBUG_ASSERT(nullptr != mem_res, "");
+    }
+
+    function_base(const function_base& other)
+        : any_handler_{other.any_handler_.get_memory_resource()}
+    {
+        if (other.any_handler_.has_value())
+        {
+            any_handler_ = other.any_handler_;
+            handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+
+            CETL_DEBUG_ASSERT(any_handler_.has_value(), "");
+            CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
+        }
+    }
+
+    function_base(function_base&& other) noexcept
+        : any_handler_{other.any_handler_.get_memory_resource()}
+    {
+        if (other.any_handler_.has_value())
+        {
+            any_handler_       = std::move(other.any_handler_);
+            handler_ptr_       = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+            other.handler_ptr_ = nullptr;
+
+            CETL_DEBUG_ASSERT(any_handler_.has_value(), "");
+            CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
+        }
+    }
+
+    // TODO: Add Callable constraint.
+    template <typename Functor>
+    function_base(Functor&& functor)
+        : any_handler_{get_default_resource(),
+                       detail::functor_handler<Functor, Result, Args...>{std::forward<Functor>(functor)}}
+        , handler_ptr_{get_if<detail::function_handler<Result, Args...>>(&any_handler_)}
+    {
+        CETL_DEBUG_ASSERT(any_handler_.has_value(), "");
+        CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
+    }
+
+    // TODO: Add Callable constraint.
+    template <typename Functor>
+    function_base(memory_resource* const mem_res, Functor&& functor)
+        : any_handler_{mem_res, detail::functor_handler<Functor, Result, Args...>{std::forward<Functor>(functor)}}
+        , handler_ptr_{get_if<detail::function_handler<Result, Args...>>(&any_handler_)}
+    {
+        CETL_DEBUG_ASSERT(any_handler_.has_value(), "");
+        CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
+    }
+
+    // TODO: Add Callable constraint.
+    template <typename Functor>
+    function_base& operator=(Functor&& functor)
+    {
+        function_base tmp{any_handler_.get_memory_resource(), std::forward<Functor>(functor)};
+        tmp.swap(*this);
+        return *this;
+    }
+
+    void swap(function_base& other) noexcept
+    {
+        any_handler_.swap(other.any_handler_);
+
+        handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+        other.handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&other.any_handler_);
+    }
+
+    CETL_NODISCARD memory_resource* get_memory_resource() const noexcept
+    {
+        return any_handler_.get_memory_resource();
+    }
+
+protected:
+    // TODO: Invest (later) into exploiting `Copyable` & `Movable` template params of our `unbounded_variant` -
+    // maybe we can make our `function_base` itself `Copyable` & `Movable` parametrized (aka `std::move_only_function`).
+    unbounded_variant<Footprint, true, true, alignof(std::max_align_t), true /*IsPmr*/> any_handler_;
+    detail::function_handler<Result, Args...>*                                          handler_ptr_{nullptr};
+
+}; // function_base
+
+}  // namespace detail
+
+template <typename Result, typename... Args, std::size_t Footprint, bool IsPmr>
+class function<Result(Args...), Footprint, IsPmr> final
+    : public detail::function_base<Result(Args...), Footprint, IsPmr>
+{
+    using base = detail::function_base<Result(Args...), Footprint, IsPmr>;
+
+public:
+    using base::base;
+    using base::swap;
+    using base::operator=;
+    using result_type = Result;
+
+    function() noexcept                 = default;
+    function(const function& other)     = default;
+    function(function&& other) noexcept = default;
+    ~function()                         = default;
+
+    function(std::nullptr_t) noexcept {};
 
     function& operator=(const function& other)
     {
@@ -157,57 +286,31 @@ public:
 
     function& operator=(std::nullptr_t) noexcept
     {
-        any_handler_.reset();
-        handler_ptr_ = nullptr;
+        base::any_handler_.reset();
+        base::handler_ptr_ = nullptr;
         return *this;
-    }
-
-    // TODO: add Callable constraint
-    template <typename Functor>
-    function& operator=(Functor&& functor)
-    {
-        function(std::forward<Functor>(functor)).swap(*this);
-        return *this;
-    }
-
-    template <typename Functor>
-    function& operator=(std::reference_wrapper<Functor> functor) noexcept
-    {
-        function(functor).swap(*this);
-        return *this;
-    }
-
-    void swap(function& other) noexcept
-    {
-        any_handler_.swap(other.any_handler_);
-        std::swap(handler_ptr_, other.handler_ptr_);
     }
 
     explicit operator bool() const noexcept
     {
-        CETL_DEBUG_ASSERT(any_handler_.has_value() == (nullptr != handler_ptr_), "");
+        CETL_DEBUG_ASSERT(base::any_handler_.has_value() == (nullptr != base::handler_ptr_), "");
 
-        return any_handler_.has_value();
+        return base::any_handler_.has_value();
     }
 
     Result operator()(Args... args) const
     {
-        CETL_DEBUG_ASSERT(any_handler_.has_value(), "");
-        CETL_DEBUG_ASSERT(nullptr != handler_ptr_, "");
+        CETL_DEBUG_ASSERT(base::any_handler_.has_value(), "");
+        CETL_DEBUG_ASSERT(nullptr != base::handler_ptr_, "");
 
-        return handler_ptr_->operator()(args...);
+        return base::handler_ptr_->operator()(args...);
     }
-
-private:
-    // TODO: Invest (later) into exploiting `Copyable` & `Movable` template params of our `unbounded_variant` -
-    // maybe we can make our `function` itself `Copyable` & `Movable` parametrized (aka `std::move_only_function`).
-    unbounded_variant<Footprint>               any_handler_;
-    detail::function_handler<Result, Args...>* handler_ptr_{nullptr};
 
 };  // function
 
-template <typename Result, typename... Args, std::size_t Footprint>
-inline void swap(function<Result(Args...), Footprint>& lhs, function<Result(Args...), Footprint>& rhs) noexcept
+template <typename Result, typename... Args, std::size_t Footprint, bool IsPmr = false>
+inline void swap(function<Result(Args...), Footprint, IsPmr>& lhs,
+                 function<Result(Args...), Footprint, IsPmr>& rhs) noexcept
 {
     lhs.swap(rhs);
 }

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -1,0 +1,194 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef CETL_PMR_FUNCTION_H_INCLUDED
+#define CETL_PMR_FUNCTION_H_INCLUDED
+
+#ifndef CETL_H_ERASE
+#    include "cetl/cetl.hpp"
+#endif
+
+#include "cetl/unbounded_variant.hpp"
+
+#include <cstddef>
+#include <exception>
+#include <functional>
+
+namespace cetl
+{
+namespace pmr
+{
+
+template <typename Signature, std::size_t Footprint>
+class function;
+
+/// Internal implementation details. Not supposed to be used directly by the users of the library.
+///
+namespace detail
+{
+
+// 436C9E2B-96E3-4483-9D2B-32B5147A0314
+using function_handler_typeid_t = cetl::
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+    type_id_type<0x43, 0x6C, 0x9E, 0x2B, 0x96, 0xE3, 0x44, 0x83, 0x9D, 0x2B, 0x32, 0xB5, 0x14, 0x7A, 0x03, 0x14>;
+
+/// @brief Provides an abstract interface for copyable functors.
+///
+template <typename Result, typename... Args>
+class function_handler : public rtti_helper<function_handler_typeid_t>
+{
+public:
+    virtual Result operator()(Args&&...) const = 0;
+
+};  // function_handler
+
+// DCAAADD6-BC73-4E3C-85B7-E9473641E737
+using functor_handler_typeid_t = cetl::
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+    type_id_type<0xDC, 0xAA, 0xAD, 0xD6, 0xBC, 0x73, 0x4E, 0x3C, 0x85, 0xB7, 0xE9, 0x47, 0x36, 0x41, 0xE7, 0x37>;
+
+template <typename Functor, typename Result, typename... Args>
+class functor_handler final : public rtti_helper<functor_handler_typeid_t, function_handler<Result, Args...>>
+{
+public:
+    explicit functor_handler(Functor&& functor) noexcept
+    : functor_{std::move(functor)}
+    {
+    }
+
+    Result operator()(Args&&... args) const override
+    {
+        return functor_(std::forward<Args>(args)...);
+    }
+
+private:
+    Functor functor_;
+};
+
+[[noreturn]] inline void throw_bad_function_call()
+{
+#if defined(__cpp_exceptions)
+    throw std::bad_function_call{};
+#else
+    std::terminate();
+#endif
+}
+
+}  // namespace detail
+
+template <typename Result, typename... Args, std::size_t Footprint>
+class function<Result(Args...), Footprint>
+{
+public:
+    using result_type = Result;
+
+    /// \brief Constructs an empty `function` object.
+    ///
+    constexpr function() noexcept = default;
+    constexpr function(nullptr_t) noexcept {};
+
+    /// \brief Constructs a `function` object with a copy of the content of `other`.
+    ///
+    function(const function& other)
+    {
+        if (static_cast<bool>(other))
+        {
+            any_handler_ = other.any_handler_;
+        }
+    }
+
+    /// \brief Constructs a `function` object with the content of `other` using move semantics.
+    ///
+    function(function&& other) noexcept
+    {
+        if (static_cast<bool>(other))
+        {
+            any_handler_ = std::move(other.any_handler_);
+        }
+    }
+
+    // TODO: add Callable constraint
+    template <typename Functor>
+    function(Functor&& functor)
+    : any_handler_{detail::functor_handler<Functor, Result, Args...>{std::forward<Functor>(functor)}}
+    {
+    }
+
+    ~function() = default;
+
+    function& operator=(const function& other)
+    {
+        function(other).swap(*this);
+        return *this;
+    }
+
+    function& operator=(function&& other) noexcept
+    {
+        function(std::move(other)).swap(*this);
+        return *this;
+    }
+
+    function& operator=(nullptr_t) noexcept
+    {
+        any_handler_.reset();
+        return *this;
+    }
+
+    // TODO: add Callable constraint
+    template <typename Functor>
+    function& operator=(Functor&& functor)
+    {
+        function(std::forward<Functor>(functor)).swap(*this);
+        return *this;
+    }
+
+    template <typename Functor>
+    function& operator=(std::reference_wrapper<Functor> functor) noexcept
+    {
+        function(functor).swap(*this);
+        return *this;
+    }
+
+    void swap(function& other) noexcept
+    {
+        any_handler_.swap(other.handler_);
+    }
+
+    explicit operator bool() const noexcept
+    {
+        return false;
+    }
+
+    Result operator()(Args... args) const
+    {
+        if (!any_handler_.has_value())
+        {
+            detail::throw_bad_function_call();
+        }
+
+        auto* func_handler_ptr = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+        if (func_handler_ptr == nullptr)
+        {
+            detail::throw_bad_function_call();
+        }
+
+        return func_handler_ptr->operator()(std::forward<Args>(args)...);
+    }
+
+private:
+    unbounded_variant<Footprint> any_handler_;
+
+};  // function
+
+template <typename Result, typename... Args, std::size_t Footprint>
+inline void swap(function<Result(Args...), Footprint>& lhs, function<Result(Args...), Footprint>& rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+
+}  // namespace pmr
+}  // namespace cetl
+
+#endif  // CETL_PMR_FUNCTION_H_INCLUDED

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -293,7 +293,7 @@ public:
     /// and depending on which stage of swapping the failure happened
     /// it could affect (invalidate) either of `*this` or `other` function.
     /// Use `valueless_by_exception()` method to check if a function is in such failure state,
-    /// and `reset` (or `reset(Pmr*)`) method to recover from it.
+    /// and `reset` (or `reset(Pmr*)`) method (or assign a new value) to recover from it.
     ///
     void swap(function& other) noexcept
     {
@@ -303,7 +303,7 @@ public:
         other.handler_ptr_ = get_if<handler_t>(&other.any_handler_);
     }
 
-    /// True if the function is valueless b/c of an exception.
+    /// True if the function is valueless b/c of an exception or OOM.
     ///
     /// Use `reset` method (or try assign a new value) to recover from this state.
     ///
@@ -345,11 +345,11 @@ namespace std
 /// and depending on which stage of swapping the failure happened
 /// it could affect (invalidate) either of `lhs` or `rhs` function.
 /// Use `valueless_by_exception()` method to check if a function is in such failure state,
-/// and `reset` (or `reset(Pmr*)`) method to recover from it.
+/// and `reset` (or `reset(Pmr*)`) method (or assign a new value) to recover from it.
 ///
 template <typename Result, typename... Args, std::size_t Footprint, typename Pmr = void>
-inline void swap(cetl::pmr::function<Result(Args...), Footprint, Pmr>& lhs,
-                 cetl::pmr::function<Result(Args...), Footprint, Pmr>& rhs) noexcept
+void swap(cetl::pmr::function<Result(Args...), Footprint, Pmr>& lhs,
+          cetl::pmr::function<Result(Args...), Footprint, Pmr>& rhs) noexcept
 {
     lhs.swap(rhs);
 }

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -91,7 +91,7 @@ public:
 
     /// \brief Constructs an empty `function` object.
     ///
-    constexpr function(nullptr_t) noexcept {};
+    function(nullptr_t) noexcept {};
 
     /// \brief Constructs a `function` object with a copy of the content of `other`.
     ///

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -155,7 +155,7 @@ public:
         return *this;
     }
 
-    function& operator=(nullptr_t) noexcept
+    function& operator=(std::nullptr_t) noexcept
     {
         any_handler_.reset();
         handler_ptr_ = nullptr;

--- a/include/cetl/pmr/function.hpp
+++ b/include/cetl/pmr/function.hpp
@@ -138,7 +138,7 @@ public:
     {
         any_handler_.swap(other.any_handler_);
 
-        handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+        handler_ptr_       = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
         other.handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&other.any_handler_);
     }
 
@@ -228,7 +228,7 @@ public:
     {
         any_handler_.swap(other.any_handler_);
 
-        handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
+        handler_ptr_       = get_if<detail::function_handler<Result, Args...>>(&any_handler_);
         other.handler_ptr_ = get_if<detail::function_handler<Result, Args...>>(&other.any_handler_);
     }
 
@@ -243,7 +243,7 @@ protected:
     unbounded_variant<Footprint, true, true, alignof(std::max_align_t), true /*IsPmr*/> any_handler_;
     detail::function_handler<Result, Args...>*                                          handler_ptr_{nullptr};
 
-}; // function_base
+};  // function_base
 
 }  // namespace detail
 

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -1,0 +1,140 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef CETL_PMR_INTERFACE_PTR_H_INCLUDED
+#define CETL_PMR_INTERFACE_PTR_H_INCLUDED
+
+#ifndef CETL_H_ERASE
+#    include "cetl/cetl.hpp"
+#endif
+
+#include "cetl/unbounded_variant.hpp"
+
+#include <memory>
+
+namespace cetl
+{
+namespace pmr
+{
+
+template <typename Interface>
+class PmrInterfaceDeleter final
+{
+public:
+    template <typename PmrAllocator>
+    PmrInterfaceDeleter(const PmrAllocator& alloc, std::size_t count)
+        : some_deallocator_{PmrRawDeallocator<PmrAllocator>{alloc, count}}
+        , type_caster_{[](Interface* ptr) { return raw_cast<typename PmrAllocator::value_type>(ptr); }}
+    {
+    }
+
+    template <typename Up>
+    PmrInterfaceDeleter(const PmrInterfaceDeleter<Up>& other)
+        : some_deallocator_{other.some_deallocator_}
+        , type_caster_{[](Interface* ptr) { return raw_cast<Up>(ptr); }}
+    {
+    }
+
+    void operator()(Interface* ptr) noexcept
+    {
+        if (nullptr != ptr)
+        {
+            if (auto deallocator = cetl::get_if<IRawDeallocator>(&some_deallocator_))
+            {
+                auto* const raw_ptr = type_caster_(ptr);
+                deallocator->operator()(static_cast<void*>(raw_ptr));
+            }
+        }
+    }
+
+private:
+    template <typename Up>
+    friend class PmrInterfaceDeleter;
+
+    template <typename Concrete>
+    static void* raw_cast(Interface* ptr) noexcept
+    {
+        return static_cast<void*>(static_cast<Concrete*>(ptr));
+    }
+
+    // D4BB1B80-612D-4330-9807-E4B2E2D76220
+    using IRawDeallocatorTypeIdType = cetl::
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        type_id_type<0xD4, 0xBB, 0x1B, 0x80, 0x61, 0x2D, 0x43, 0x30, 0x98, 0x07, 0xE4, 0xB2, 0xE2, 0xD7, 0x62, 0x20>;
+
+    // 2BBEAF90-7CFF-4AB8-ACBF-7C582EE66414
+    using PmrRawDeallocatorTypeIdType = cetl::
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        type_id_type<0x2B, 0xBE, 0xAF, 0x90, 0x7C, 0xFF, 0x4A, 0xB8, 0xAC, 0xBF, 0x7C, 0x58, 0x2E, 0xE6, 0x64, 0x14>;
+
+    class IRawDeallocator : public cetl::rtti_helper<IRawDeallocatorTypeIdType>
+    {
+    public:
+        virtual void operator()(void* raw_ptr) = 0;
+    };
+
+    template <typename PmrAllocator>
+    class PmrRawDeallocator final : public cetl::rtti_helper<PmrRawDeallocatorTypeIdType, IRawDeallocator>
+    {
+    public:
+        PmrRawDeallocator(const PmrAllocator& alloc, std::size_t count)
+            : alloc_{alloc}
+            , count_{count}
+        {
+        }
+
+        // IRawDeallocator
+
+        void operator()(void* raw_ptr) override
+        {
+            using Concrete = typename PmrAllocator::value_type;
+
+            if (nullptr != raw_ptr)
+            {
+                auto concrete_ptr = static_cast<Concrete*>(raw_ptr);
+                concrete_ptr->~Concrete();
+                alloc_.deallocate(concrete_ptr, count_);
+            }
+        }
+
+        PmrAllocator alloc_;
+        std::size_t  count_;
+
+    };  // PmrRawDeallocator
+
+    cetl::unbounded_variant<3 * sizeof(void*)> some_deallocator_;
+    void* (*type_caster_)(Interface*);
+
+};  // PmrInterfaceDeleter
+
+template <typename Interface>
+using InterfacePtr = std::unique_ptr<Interface, PmrInterfaceDeleter<Interface>>;
+
+class InterfaceFactory final
+{
+public:
+    ~InterfaceFactory() = delete;
+    InterfaceFactory()  = delete;
+
+    template <typename Interface, typename PmrAllocator, typename... Args>
+    static InterfacePtr<Interface> make_unique(PmrAllocator alloc, Args&&... args)
+    {
+        using Concrete = typename PmrAllocator::value_type;
+
+        InterfacePtr<Concrete> concrete_ptr{alloc.allocate(1), PmrInterfaceDeleter<Concrete>{alloc, 1}};
+        if (nullptr != concrete_ptr)
+        {
+            alloc.construct(concrete_ptr.get(), std::forward<Args>(args)...);
+        }
+
+        return concrete_ptr;
+    }
+
+};  // InterfaceFactory
+
+}  // namespace pmr
+}  // namespace cetl
+
+#endif  // CETL_PMR_INTERFACE_PTR_H_INCLUDED

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -10,8 +10,6 @@
 #    include "cetl/cetl.hpp"
 #endif
 
-#include "cetl/unbounded_variant.hpp"
-
 #include <memory>
 #include <functional>
 

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    template <typename Down>
+    template <typename Down, typename = std::enable_if_t<std::is_base_of<Interface, Down>::value>>
     PmrInterfaceDeleter(const PmrInterfaceDeleter<Down>& other)
         : deleter_{other.get_memory_resource(), [other](Interface* ptr) {
                        // Delegate to the down class deleter.

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -10,6 +10,8 @@
 #    include "cetl/cetl.hpp"
 #endif
 
+#include "cetl/pmr/function.hpp"
+
 #include <memory>
 #include <functional>
 
@@ -55,7 +57,7 @@ private:
     template <typename Down>
     friend class PmrInterfaceDeleter;
 
-    std::function<void(Interface*)> deleter_;
+    cetl::pmr::function<void(Interface*), 24> deleter_;
 
 };  // PmrInterfaceDeleter
 

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -29,7 +29,6 @@ template <typename Interface>
 class PmrInterfaceDeleter final
 {
 public:
-
     /// Constructs a Concrete type-erased deleter for the given interface type.
     ///
     /// @tparam PmrAllocator The type of the polymorphic allocator to use for deallocation.

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -13,6 +13,7 @@
 #include "cetl/unbounded_variant.hpp"
 
 #include <memory>
+#include <functional>
 
 namespace cetl
 {
@@ -24,88 +25,39 @@ class PmrInterfaceDeleter final
 {
 public:
     template <typename PmrAllocator>
-    PmrInterfaceDeleter(const PmrAllocator& alloc, std::size_t count)
-        : some_deallocator_{PmrRawDeallocator<PmrAllocator>{alloc, count}}
-        , type_caster_{[](Interface* ptr) { return raw_cast<typename PmrAllocator::value_type>(ptr); }}
+    PmrInterfaceDeleter(PmrAllocator alloc, std::size_t obj_count)
     {
+        deleter_ = [alloc, obj_count](Interface* ptr) mutable {
+            using Concrete     = typename PmrAllocator::value_type;
+            auto* concrete_ptr = static_cast<Concrete*>(ptr);
+
+            concrete_ptr->~Concrete();
+            alloc.deallocate(concrete_ptr, obj_count);
+        };
     }
 
-    template <typename Up>
-    PmrInterfaceDeleter(const PmrInterfaceDeleter<Up>& other)
-        : some_deallocator_{other.some_deallocator_}
-        , type_caster_{[](Interface* ptr) { return raw_cast<Up>(ptr); }}
+    template <typename Down>
+    PmrInterfaceDeleter(const PmrInterfaceDeleter<Down>& other)
     {
+        deleter_ = [other](Interface* ptr) {
+            // Delegate to the down class deleter.
+            other.deleter_(static_cast<Down*>(ptr));
+        };
     }
 
     void operator()(Interface* ptr) noexcept
     {
         if (nullptr != ptr)
         {
-            if (auto deallocator = cetl::get_if<IRawDeallocator>(&some_deallocator_))
-            {
-                auto* const raw_ptr = type_caster_(ptr);
-                deallocator->operator()(static_cast<void*>(raw_ptr));
-            }
+            deleter_(ptr);
         }
     }
 
 private:
-    template <typename Up>
+    template <typename Down>
     friend class PmrInterfaceDeleter;
 
-    template <typename Concrete>
-    static void* raw_cast(Interface* ptr) noexcept
-    {
-        return static_cast<void*>(static_cast<Concrete*>(ptr));
-    }
-
-    // D4BB1B80-612D-4330-9807-E4B2E2D76220
-    using IRawDeallocatorTypeIdType = cetl::
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-        type_id_type<0xD4, 0xBB, 0x1B, 0x80, 0x61, 0x2D, 0x43, 0x30, 0x98, 0x07, 0xE4, 0xB2, 0xE2, 0xD7, 0x62, 0x20>;
-
-    // 2BBEAF90-7CFF-4AB8-ACBF-7C582EE66414
-    using PmrRawDeallocatorTypeIdType = cetl::
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-        type_id_type<0x2B, 0xBE, 0xAF, 0x90, 0x7C, 0xFF, 0x4A, 0xB8, 0xAC, 0xBF, 0x7C, 0x58, 0x2E, 0xE6, 0x64, 0x14>;
-
-    class IRawDeallocator : public cetl::rtti_helper<IRawDeallocatorTypeIdType>
-    {
-    public:
-        virtual void operator()(void* raw_ptr) = 0;
-    };
-
-    template <typename PmrAllocator>
-    class PmrRawDeallocator final : public cetl::rtti_helper<PmrRawDeallocatorTypeIdType, IRawDeallocator>
-    {
-    public:
-        PmrRawDeallocator(const PmrAllocator& alloc, std::size_t count)
-            : alloc_{alloc}
-            , count_{count}
-        {
-        }
-
-        // IRawDeallocator
-
-        void operator()(void* raw_ptr) override
-        {
-            using Concrete = typename PmrAllocator::value_type;
-
-            if (nullptr != raw_ptr)
-            {
-                auto concrete_ptr = static_cast<Concrete*>(raw_ptr);
-                concrete_ptr->~Concrete();
-                alloc_.deallocate(concrete_ptr, count_);
-            }
-        }
-
-        PmrAllocator alloc_;
-        std::size_t  count_;
-
-    };  // PmrRawDeallocator
-
-    cetl::unbounded_variant<3 * sizeof(void*)> some_deallocator_;
-    void* (*type_caster_)(Interface*);
+    std::function<void(Interface*)> deleter_;
 
 };  // PmrInterfaceDeleter
 

--- a/include/cetl/pmr/interface_ptr.hpp
+++ b/include/cetl/pmr/interface_ptr.hpp
@@ -16,34 +16,20 @@ namespace cetl
 namespace pmr
 {
 
-template <typename Interface, typename Pmr>
+template <typename Interface>
 class PmrInterfaceDeleter final
 {
 public:
     template <typename PmrAllocator>
     PmrInterfaceDeleter(PmrAllocator alloc, std::size_t obj_count)
-        : deleter_{alloc.resource(), [alloc, obj_count](Interface* ptr) mutable {
-                       using Concrete     = typename PmrAllocator::value_type;
-                       auto* concrete_ptr = static_cast<Concrete*>(ptr);
+        : deleter_{[alloc, obj_count](Interface* ptr) mutable {
+            using Concrete = typename PmrAllocator::value_type;
 
-                       concrete_ptr->~Concrete();
-                       alloc.deallocate(concrete_ptr, obj_count);
-                   }}
+            auto* concrete_ptr = static_cast<Concrete*>(ptr);
+            concrete_ptr->~Concrete();
+            alloc.deallocate(concrete_ptr, obj_count);
+        }}
     {
-    }
-
-    template <typename Down, typename = std::enable_if_t<std::is_base_of<Interface, Down>::value>>
-    PmrInterfaceDeleter(const PmrInterfaceDeleter<Down, Pmr>& other)
-        : deleter_{other.get_memory_resource(), [other](Interface* ptr) {
-                       // Delegate to the down class deleter.
-                       other.deleter_(static_cast<Down*>(ptr));
-                   }}
-    {
-    }
-
-    Pmr* get_memory_resource() const noexcept
-    {
-        return deleter_.get_memory_resource();
     }
 
     void operator()(Interface* ptr) noexcept
@@ -51,16 +37,36 @@ public:
         deleter_(ptr);
     }
 
-private:
-    template <typename Down, typename PmrT>
-    friend class PmrInterfaceDeleter;
+    // Below convertor constructor is only possible with enabled PMR at `function`.
+    // For now, we decided to comment it out, so that `InterfacePtr` always stays
+    // within 24-bytes small object optimization, namely without extra memory allocation
+    // just for the sake of "advanced" deleter (actually chain of casters down to original `Concrete` pointer).
+    //
+    //    template <typename Down, typename = std::enable_if_t<std::is_base_of<Interface, Down>::value>>
+    //    PmrInterfaceDeleter(const PmrInterfaceDeleter<Down, Pmr>& other)
+    //        : deleter_{other.get_memory_resource(), [other](Interface* ptr) {
+    //                       // Delegate to the down class deleter.
+    //                       other.deleter_(static_cast<Down*>(ptr));
+    //                   }}
+    //    {
+    //    }
+    //
+    //    Pmr* get_memory_resource() const noexcept
+    //    {
+    //        return deleter_.get_memory_resource();
+    //    }
+    //
+    // private:
+    //    template <typename Down, typename PmrT>
+    //    friend class PmrInterfaceDeleter;
 
-    cetl::pmr::function<void(Interface*), 24, Pmr> deleter_;
+private:
+    cetl::pmr::function<void(Interface*), 24> deleter_;
 
 };  // PmrInterfaceDeleter
 
-template <typename Interface, typename Pmr>
-using InterfacePtr = std::unique_ptr<Interface, PmrInterfaceDeleter<Interface, Pmr>>;
+template <typename Interface>
+using InterfacePtr = std::unique_ptr<Interface, PmrInterfaceDeleter<Interface>>;
 
 class InterfaceFactory final
 {
@@ -69,20 +75,83 @@ public:
     InterfaceFactory()  = delete;
 
     template <typename Interface, typename PmrAllocator, typename... Args>
-    static auto make_unique(PmrAllocator alloc, Args&&... args)
-        -> InterfacePtr<Interface, std::remove_pointer_t<decltype(alloc.resource())>>
+    CETL_NODISCARD static InterfacePtr<Interface> make_unique(PmrAllocator alloc, Args&&... args)
     {
-        using Concrete = typename PmrAllocator::value_type;
-        using Pmr      = std::remove_pointer_t<decltype(alloc.resource())>;
-
-        InterfacePtr<Concrete, Pmr> concrete_ptr{alloc.allocate(1), PmrInterfaceDeleter<Concrete, Pmr>{alloc, 1}};
-        if (nullptr != concrete_ptr)
+        // Allocate memory for the concrete object.
+        // Then try to construct it in-place - it could potentially throw,
+        // so RAII will deallocate the memory BUT won't try to destroy the uninitialized object!
+        //
+        ConcreteRaii<PmrAllocator> concrete_raii{alloc};
+        if (auto* const concrete_ptr = concrete_raii.get())
         {
-            alloc.construct(concrete_ptr.get(), std::forward<Args>(args)...);
+            concrete_raii.construct(std::forward<Args>(args)...);
         }
 
-        return concrete_ptr;
+        // Everything is good, so now we can move ownership of the concrete object to the interface pointer.
+        //
+        return InterfacePtr<Interface>{concrete_raii.release(), PmrInterfaceDeleter<Interface>{alloc, 1}};
     }
+
+private:
+    template <typename PmrAllocator>
+    class ConcreteRaii final
+    {
+        using Concrete = typename PmrAllocator::value_type;
+
+    public:
+        ConcreteRaii(PmrAllocator& pmr_allocator)
+            : concrete_{pmr_allocator.allocate(1)}
+            , constructed_{false}
+            , pmr_allocator_{pmr_allocator}
+        {
+        }
+        ~ConcreteRaii()
+        {
+            if (nullptr != concrete_)
+            {
+                if (constructed_)
+                {
+                    concrete_->~Concrete();
+                }
+                pmr_allocator_.deallocate(concrete_, 1);
+            }
+        }
+        ConcreteRaii(const ConcreteRaii&)                = delete;
+        ConcreteRaii(ConcreteRaii&&) noexcept            = delete;
+        ConcreteRaii& operator=(const ConcreteRaii&)     = delete;
+        ConcreteRaii& operator=(ConcreteRaii&&) noexcept = delete;
+
+        template <typename... Args>
+        void construct(Args&&... args)
+        {
+            CETL_DEBUG_ASSERT(constructed_ == false, "");
+
+            if (nullptr != concrete_)
+            {
+                pmr_allocator_.construct(concrete_, std::forward<Args>(args)...);
+                constructed_ = true;
+            }
+        }
+
+        Concrete* get() const noexcept
+        {
+            return concrete_;
+        }
+
+        Concrete* release()
+        {
+            constructed_ = false;
+            Concrete* result{nullptr};
+            std::swap(result, concrete_);
+            return result;
+        }
+
+    private:
+        Concrete*     concrete_;
+        bool          constructed_;
+        PmrAllocator& pmr_allocator_;
+
+    };  // ConcreteRaii
 
 };  // InterfaceFactory
 

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -116,10 +116,10 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
     }
 
-    pmr::memory_resource& get_memory_resource() const noexcept
+    pmr::memory_resource* get_memory_resource() const noexcept
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
-        return *mem_res_;
+        return mem_res_;
     }
 
     template <typename Tp>
@@ -128,7 +128,7 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
         CETL_DEBUG_ASSERT((0UL == allocated_size_) && (nullptr == allocated_buffer_),
                           "This object is expected to be a brand new one.");
 
-        allocated_buffer_ = static_cast<cetl::byte*>(get_memory_resource().allocate(sizeof(Tp), Alignment));
+        allocated_buffer_ = static_cast<cetl::byte*>(get_memory_resource()->allocate(sizeof(Tp), Alignment));
         allocated_size_   = (nullptr != allocated_buffer_) ? sizeof(Tp) : 0;
     }
 
@@ -145,7 +145,7 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
         if (src.allocated_size_ > 0UL)
         {
             allocated_buffer_ =
-                static_cast<cetl::byte*>(get_memory_resource().allocate(src.allocated_size_, Alignment));
+                static_cast<cetl::byte*>(get_memory_resource()->allocate(src.allocated_size_, Alignment));
             allocated_size_ = (nullptr != allocated_buffer_) ? src.allocated_size_ : 0;
         }
     }
@@ -172,7 +172,7 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
 
         if (nullptr != allocated_buffer_)
         {
-            get_memory_resource().deallocate(allocated_buffer_, allocated_size_, Alignment);
+            get_memory_resource()->deallocate(allocated_buffer_, allocated_size_, Alignment);
             allocated_buffer_ = nullptr;
             allocated_size_   = 0;
         }
@@ -218,10 +218,10 @@ struct base_storage<Footprint, true /*IsPmr*/, Alignment>
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
     }
 
-    pmr::memory_resource& get_memory_resource() const noexcept
+    pmr::memory_resource* get_memory_resource() const noexcept
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
-        return *mem_res_;
+        return mem_res_;
     }
 
     template <typename Tp>
@@ -232,7 +232,7 @@ struct base_storage<Footprint, true /*IsPmr*/, Alignment>
 
         if (sizeof(Tp) > Footprint)
         {
-            allocated_buffer_ = static_cast<cetl::byte*>(get_memory_resource().allocate(sizeof(Tp), Alignment));
+            allocated_buffer_ = static_cast<cetl::byte*>(get_memory_resource()->allocate(sizeof(Tp), Alignment));
             allocated_size_   = (nullptr != allocated_buffer_) ? sizeof(Tp) : 0;
         }
     }
@@ -250,7 +250,7 @@ struct base_storage<Footprint, true /*IsPmr*/, Alignment>
         if (src.allocated_size_ > 0UL)
         {
             allocated_buffer_ =
-                static_cast<cetl::byte*>(get_memory_resource().allocate(src.allocated_size_, Alignment));
+                static_cast<cetl::byte*>(get_memory_resource()->allocate(src.allocated_size_, Alignment));
             allocated_size_ = (nullptr != allocated_buffer_) ? src.allocated_size_ : 0;
         }
     }
@@ -277,7 +277,7 @@ struct base_storage<Footprint, true /*IsPmr*/, Alignment>
 
         if (nullptr != allocated_buffer_)
         {
-            get_memory_resource().deallocate(allocated_buffer_, allocated_size_, Alignment);
+            get_memory_resource()->deallocate(allocated_buffer_, allocated_size_, Alignment);
             allocated_buffer_ = nullptr;
             allocated_size_   = 0;
         }
@@ -1052,6 +1052,13 @@ public:
     CETL_NODISCARD bool has_value() const noexcept
     {
         return base::has_value();
+    }
+
+    CETL_NODISCARD pmr::memory_resource* get_memory_resource() const noexcept
+    {
+        static_assert(IsPmr, "Cannot construct non-PMR unbounded_variant with memory resource.");
+
+        return base::get_memory_resource();
     }
 
 private:

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -16,10 +16,6 @@
 #include <algorithm>
 #include <initializer_list>
 
-#ifndef CETL_H_ERASE
-#    include "cetl/cetl.hpp"
-#endif
-
 namespace cetl
 {
 
@@ -48,7 +44,7 @@ public:
 #endif  // defined(__cpp_exceptions) || defined(CETL_DOXYGEN)
 
 // Forward declarations
-template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment, bool IsPmr>
+template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment, typename Pmr>
 class unbounded_variant;
 
 namespace detail
@@ -73,17 +69,38 @@ inline std::nullptr_t throw_bad_alloc()
 #endif
 }
 
+template <typename Pmr>
+using IsPmr = std::integral_constant<bool, !std::is_void<Pmr>::value>;
+
+template <typename Pmr>
+using EnableIfPmrT = std::enable_if_t<IsPmr<Pmr>::value>;
+
+template <typename Pmr>
+using EnableIfNotPmrT = std::enable_if_t<!IsPmr<Pmr>::value>;
+
 // MARK: - Storage policy.
 //
-template <std::size_t Footprint, bool IsPmr, std::size_t Alignment>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
 struct base_storage;
 //
-// In-Place only case.
-template <std::size_t Footprint, std::size_t Alignment>
-struct base_storage<Footprint, false /*IsPmr*/, Alignment>
+// Invalid non-PMR and zero footprint case.
+template <std::size_t Alignment>
+struct base_storage<void /*Pmr*/, 0UL /*Footprint*/, Alignment>
 {
     template <typename Tp>
-    constexpr void check_footprint() noexcept
+    void check_footprint() const noexcept
+    {
+        // Non-PMR storage can store any value as long as it fits into the footprint,
+        // which is not possible with zero footprint.
+        static_assert(sizeof(Tp) <= 0, "Make non-zero footprint, or enable PMR support.");
+    }
+};
+// In-Place only case (no PMR at all).
+template <std::size_t Footprint, std::size_t Alignment>
+struct base_storage<void /*Pmr*/, Footprint, Alignment>
+{
+    template <typename Tp>
+    void check_footprint() const noexcept
     {
         // Non-PMR storage can store any value as long as it fits into the footprint.
         static_assert(sizeof(Tp) <= Footprint, "Enlarge the footprint");
@@ -158,25 +175,24 @@ private:
     // NB! It's intentional and by design that the `inplace_buffer_` is the very first member of `unbounded_variant`
     // memory layout. In such way pointer to a `unbounded_variant` and its stored value are the same -
     // could be useful during debugging/troubleshooting.
-    alignas(Alignment) cetl::byte inplace_buffer_[std::max(Footprint, 1UL)];
+    alignas(Alignment) std::uint8_t inplace_buffer_[std::max(Footprint, 1UL)];
 
     // Stores the size of the allocated space in the buffer for a value.
     // The size could be less than `Footprint`, but never zero except when variant is empty (valid and valueless).
     std::size_t value_size_{0UL};
 };
-//
-// PMR only case.
-template <std::size_t Alignment>
-struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
+// PMR only case (zero in-place footprint).
+template <typename Pmr, std::size_t Alignment>
+struct base_storage<Pmr, 0UL /*Footprint*/, Alignment>
 {
     base_storage()
         : value_size_{0UL}
         , allocated_buffer_{nullptr}
-        , mem_res_{cetl::pmr::get_default_resource()}
+        , mem_res_{nullptr}
     {
     }
 
-    explicit base_storage(pmr::memory_resource* const mem_res)
+    explicit base_storage(Pmr* const mem_res)
         : value_size_{0UL}
         , allocated_buffer_{nullptr}
         , mem_res_{mem_res}
@@ -185,24 +201,24 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
     }
 
     template <typename Tp>
-    constexpr void check_footprint() noexcept
+    void check_footprint() const noexcept
     {
         // PMR-based storage can store any size of the value.
     }
 
-    CETL_NODISCARD pmr::memory_resource* get_memory_resource() const noexcept
+    CETL_NODISCARD Pmr* get_memory_resource() const noexcept
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
         return mem_res_;
     }
 
-    pmr::memory_resource* set_memory_resource(pmr::memory_resource* const mem_res) noexcept
+    Pmr* set_memory_resource(Pmr* const mem_res) noexcept
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res, "");
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
 
-        pmr::memory_resource* tmp = mem_res_;
-        mem_res_                  = mem_res;
+        Pmr* tmp = mem_res_;
+        mem_res_ = mem_res;
         return tmp;
     }
 
@@ -229,7 +245,7 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
         //
         value_size_ = size_bytes;
 
-        allocated_buffer_ = static_cast<cetl::byte*>(get_memory_resource()->allocate(size_bytes, Alignment));
+        allocated_buffer_ = static_cast<std::uint8_t*>(get_memory_resource()->allocate(size_bytes, Alignment));
         if (nullptr == allocated_buffer_)
         {
             return throw_bad_alloc();
@@ -318,23 +334,22 @@ struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
 
 private:
     // Stores the size of the allocated buffer for a value.
-    std::size_t           value_size_;
-    cetl::byte*           allocated_buffer_;
-    pmr::memory_resource* mem_res_;
+    std::size_t   value_size_;
+    std::uint8_t* allocated_buffer_;
+    Pmr*          mem_res_;
 };
-//
 // Both PMR & In-Place case.
-template <std::size_t Footprint, std::size_t Alignment>
-struct base_storage<Footprint, true /*IsPmr*/, Alignment>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
+struct base_storage
 {
     base_storage()
         : value_size_{0UL}
         , allocated_buffer_{nullptr}
-        , mem_res_{cetl::pmr::get_default_resource()}
+        , mem_res_{nullptr}
     {
     }
 
-    explicit base_storage(pmr::memory_resource* const mem_res)
+    explicit base_storage(Pmr* const mem_res)
         : value_size_{0UL}
         , allocated_buffer_{nullptr}
         , mem_res_{mem_res}
@@ -343,24 +358,24 @@ struct base_storage<Footprint, true /*IsPmr*/, Alignment>
     }
 
     template <typename Tp>
-    constexpr void check_footprint() noexcept
+    void check_footprint() const noexcept
     {
         // PMR-based storage can store any size of the value.
     }
 
-    CETL_NODISCARD pmr::memory_resource* get_memory_resource() const noexcept
+    CETL_NODISCARD Pmr* get_memory_resource() const noexcept
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
         return mem_res_;
     }
 
-    pmr::memory_resource* set_memory_resource(pmr::memory_resource* const mem_res) noexcept
+    Pmr* set_memory_resource(Pmr* const mem_res) noexcept
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res, "");
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
 
-        pmr::memory_resource* tmp = mem_res_;
-        mem_res_                  = mem_res;
+        Pmr* tmp = mem_res_;
+        mem_res_ = mem_res;
         return tmp;
     }
 
@@ -392,7 +407,7 @@ struct base_storage<Footprint, true /*IsPmr*/, Alignment>
             return inplace_buffer_;
         }
 
-        allocated_buffer_ = static_cast<cetl::byte*>(get_memory_resource()->allocate(size_bytes, Alignment));
+        allocated_buffer_ = static_cast<std::uint8_t*>(get_memory_resource()->allocate(size_bytes, Alignment));
         if (nullptr == allocated_buffer_)
         {
             return throw_bad_alloc();
@@ -481,25 +496,26 @@ private:
     // NB! It's intentional and by design that the `inplace_buffer_` is the very first member of `unbounded_variant`
     // memory layout. In such way pointer to a `unbounded_variant` and its stored value are the same
     // in case of small object optimization - could be useful during debugging/troubleshooting.
-    alignas(Alignment) cetl::byte inplace_buffer_[Footprint];
+    alignas(Alignment) std::uint8_t inplace_buffer_[Footprint];
 
     // Stores the size of the allocated space in a buffer for a value.
     // The size could be either `<=Footprint` (in-place) or `>Footprint (PMR allocated),
     // but never zero except when variant is empty (valid and valueless).
-    std::size_t           value_size_;
-    cetl::byte*           allocated_buffer_;
-    pmr::memory_resource* mem_res_;
+    std::size_t   value_size_;
+    std::uint8_t* allocated_buffer_;
+    Pmr*          mem_res_;
 
 };  // base_storage
 
 // MARK: - Access policy.
 //
-template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
-struct base_access : base_storage<Footprint, IsPmr, Alignment>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
+struct base_access : base_storage<Pmr, Footprint, Alignment>
 {
     base_access() = default;
 
-    explicit base_access(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_access(Pmr* const mem_res)
         : base{mem_res}
     {
     }
@@ -564,8 +580,7 @@ struct base_access : base_storage<Footprint, IsPmr, Alignment>
     template <typename ValueType>
     CETL_NODISCARD void* get_ptr() noexcept
     {
-        static_assert(sizeof(ValueType) <= Footprint || IsPmr,
-                      "Cannot contain the requested type since the footprint is too small");
+        base::template check_footprint<ValueType>();
 
         if (!has_value())
         {
@@ -579,8 +594,7 @@ struct base_access : base_storage<Footprint, IsPmr, Alignment>
     template <typename ValueType>
     CETL_NODISCARD const void* get_ptr() const noexcept
     {
-        static_assert(sizeof(ValueType) <= Footprint || IsPmr,
-                      "Cannot contain the requested type since the footprint is too small");
+        base::template check_footprint<ValueType>();
 
         if (!has_value())
         {
@@ -609,6 +623,9 @@ struct base_access : base_storage<Footprint, IsPmr, Alignment>
 
     void reset() noexcept
     {
+        // Non-PMR storage can store any value as long as it fits into the footprint.
+        static_assert((Footprint > 0) || IsPmr<Pmr>::value, "Make non-zero footprint, or enable PMR support.");
+
         if (has_value())
         {
             value_destroyer_(base::get_raw_storage());
@@ -622,7 +639,7 @@ struct base_access : base_storage<Footprint, IsPmr, Alignment>
     }
 
 private:
-    using base = base_storage<Footprint, IsPmr, Alignment>;
+    using base = base_storage<Pmr, Footprint, Alignment>;
 
     // Holds type-erased value destroyer. `nullptr` if storage has no value stored.
     void (*value_destroyer_)(void* self) = nullptr;
@@ -636,31 +653,33 @@ private:
 
 // MARK: - Handlers policy.
 //
-template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment, bool IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment>
 struct base_handlers;
 //
-template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
-struct base_handlers<Footprint, false /*Copyable*/, false /*Moveable*/, Alignment, IsPmr>
-    : base_access<Footprint, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
+struct base_handlers<Pmr, Footprint, false /*Copyable*/, false /*Moveable*/, Alignment>
+    : base_access<Pmr, Footprint, Alignment>
 {
     base_handlers() = default;
 
-    explicit base_handlers(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_handlers(Pmr* const mem_res)
         : base{mem_res}
     {
     }
 
 private:
-    using base = base_access<Footprint, Alignment, IsPmr>;
+    using base = base_access<Pmr, Footprint, Alignment>;
 };
 //
-template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
-struct base_handlers<Footprint, true /*Copyable*/, false /*Moveable*/, Alignment, IsPmr>
-    : base_access<Footprint, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
+struct base_handlers<Pmr, Footprint, true /*Copyable*/, false /*Moveable*/, Alignment>
+    : base_access<Pmr, Footprint, Alignment>
 {
     base_handlers() = default;
 
-    explicit base_handlers(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_handlers(Pmr* const mem_res)
         : base{mem_res}
     {
     }
@@ -683,16 +702,17 @@ struct base_handlers<Footprint, true /*Copyable*/, false /*Moveable*/, Alignment
     void (*value_copier_)(const void* src, void* dst) = nullptr;
 
 private:
-    using base = base_access<Footprint, Alignment, IsPmr>;
+    using base = base_access<Pmr, Footprint, Alignment>;
 };
 //
-template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
-struct base_handlers<Footprint, false /*Copyable*/, true /*Moveable*/, Alignment, IsPmr>
-    : base_access<Footprint, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
+struct base_handlers<Pmr, Footprint, false /*Copyable*/, true /*Moveable*/, Alignment>
+    : base_access<Pmr, Footprint, Alignment>
 {
     base_handlers() = default;
 
-    explicit base_handlers(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_handlers(Pmr* const mem_res)
         : base{mem_res}
     {
     }
@@ -715,16 +735,17 @@ struct base_handlers<Footprint, false /*Copyable*/, true /*Moveable*/, Alignment
     void (*value_mover_)(void* src, void* dst) = nullptr;
 
 private:
-    using base = base_access<Footprint, Alignment, IsPmr>;
+    using base = base_access<Pmr, Footprint, Alignment>;
 };
 //
-template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
-struct base_handlers<Footprint, true /*Copyable*/, true /*Moveable*/, Alignment, IsPmr>
-    : base_access<Footprint, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, std::size_t Alignment>
+struct base_handlers<Pmr, Footprint, true /*Copyable*/, true /*Moveable*/, Alignment>
+    : base_access<Pmr, Footprint, Alignment>
 {
     base_handlers() = default;
 
-    explicit base_handlers(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_handlers(Pmr* const mem_res)
         : base{mem_res}
     {
     }
@@ -762,37 +783,38 @@ struct base_handlers<Footprint, true /*Copyable*/, true /*Moveable*/, Alignment,
     void (*value_mover_)(void* src, void* dst) = nullptr;
 
 private:
-    using base = base_access<Footprint, Alignment, IsPmr>;
+    using base = base_access<Pmr, Footprint, Alignment>;
 
 };  // base_handlers
 
 // MARK: - Copy policy.
 //
-template <std::size_t Footprint, bool Copyable, bool Moveable, std::size_t Alignment, bool IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Copyable, bool Moveable, std::size_t Alignment>
 struct base_copy;
 //
 // Non-copyable case.
-template <std::size_t Footprint, bool Moveable, std::size_t Alignment, bool IsPmr>
-struct base_copy<Footprint, false /*Copyable*/, Moveable, Alignment, IsPmr>
-    : base_handlers<Footprint, false /*Copyable*/, Moveable, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Moveable, std::size_t Alignment>
+struct base_copy<Pmr, Footprint, false /*Copyable*/, Moveable, Alignment>
+    : base_handlers<Pmr, Footprint, false /*Copyable*/, Moveable, Alignment>
 {
     base_copy()                            = default;
     base_copy(const base_copy&)            = delete;
     base_copy& operator=(const base_copy&) = delete;
 
-    explicit base_copy(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_copy(Pmr* const mem_res)
         : base{mem_res}
     {
     }
 
 private:
-    using base = base_handlers<Footprint, false, Moveable, Alignment, IsPmr>;
+    using base = base_handlers<Pmr, Footprint, false, Moveable, Alignment>;
 };
 //
 // Copyable case.
-template <std::size_t Footprint, bool Moveable, std::size_t Alignment, bool IsPmr>
-struct base_copy<Footprint, true /*Copyable*/, Moveable, Alignment, IsPmr>
-    : base_handlers<Footprint, true /*Copyable*/, Moveable, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Moveable, std::size_t Alignment>
+struct base_copy<Pmr, Footprint, true /*Copyable*/, Moveable, Alignment>
+    : base_handlers<Pmr, Footprint, true /*Copyable*/, Moveable, Alignment>
 {
     base_copy() = default;
 
@@ -802,7 +824,8 @@ struct base_copy<Footprint, true /*Copyable*/, Moveable, Alignment, IsPmr>
         copy_from(other);
     }
 
-    explicit base_copy(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_copy(Pmr* const mem_res)
         : base{mem_res}
     {
     }
@@ -830,7 +853,7 @@ struct base_copy<Footprint, true /*Copyable*/, Moveable, Alignment, IsPmr>
     }
 
 private:
-    using base = base_handlers<Footprint, true, Moveable, Alignment, IsPmr>;
+    using base = base_handlers<Pmr, Footprint, true, Moveable, Alignment>;
 
     void copy_from(const base_copy& src)
     {
@@ -850,13 +873,13 @@ private:
 
 // MARK: - Move policy.
 //
-template <std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment, bool IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Copyable, bool Movable, std::size_t Alignment>
 struct base_move;
 //
 // Non-movable case.
-template <std::size_t Footprint, bool Copyable, std::size_t Alignment, bool IsPmr>
-struct base_move<Footprint, Copyable, false /*Movable*/, Alignment, IsPmr>
-    : base_copy<Footprint, Copyable, false /*Movable*/, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Copyable, std::size_t Alignment>
+struct base_move<Pmr, Footprint, Copyable, false /*Movable*/, Alignment>
+    : base_copy<Pmr, Footprint, Copyable, false /*Movable*/, Alignment>
 {
     base_move()                     = default;
     base_move(const base_move&)     = default;
@@ -865,19 +888,20 @@ struct base_move<Footprint, Copyable, false /*Movable*/, Alignment, IsPmr>
     base_move& operator=(const base_move&)     = default;
     base_move& operator=(base_move&&) noexcept = delete;
 
-    explicit base_move(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_move(Pmr* const mem_res)
         : base{mem_res}
     {
     }
 
 private:
-    using base = base_copy<Footprint, Copyable, false, Alignment, IsPmr>;
+    using base = base_copy<Pmr, Footprint, Copyable, false, Alignment>;
 };
 //
 // Movable case.
-template <std::size_t Footprint, bool Copyable, std::size_t Alignment, bool IsPmr>
-struct base_move<Footprint, Copyable, true /*Movable*/, Alignment, IsPmr>
-    : base_copy<Footprint, Copyable, true /*Movable*/, Alignment, IsPmr>
+template <typename Pmr, std::size_t Footprint, bool Copyable, std::size_t Alignment>
+struct base_move<Pmr, Footprint, Copyable, true /*Movable*/, Alignment>
+    : base_copy<Pmr, Footprint, Copyable, true /*Movable*/, Alignment>
 {
     base_move()                            = default;
     base_move(const base_move&)            = default;
@@ -889,7 +913,8 @@ struct base_move<Footprint, Copyable, true /*Movable*/, Alignment, IsPmr>
         move_from(other);
     }
 
-    explicit base_move(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = EnableIfPmrT<PmrAlias>>
+    explicit base_move(Pmr* const mem_res)
         : base{mem_res}
     {
     }
@@ -916,7 +941,7 @@ struct base_move<Footprint, Copyable, true /*Movable*/, Alignment, IsPmr>
     }
 
 private:
-    using base = base_copy<Footprint, Copyable, true, Alignment, IsPmr>;
+    using base = base_copy<Pmr, Footprint, Copyable, true, Alignment>;
 
     void move_from(base_move& src) noexcept
     {
@@ -936,6 +961,12 @@ private:
 
 }  // namespace detail
 
+template <typename ValueType, typename UnboundedVariant>
+std::add_pointer_t<ValueType> get_if(UnboundedVariant* operand) noexcept;
+
+template <typename ValueType, typename UnboundedVariant>
+std::add_pointer_t<std::add_const_t<ValueType>> get_if(const UnboundedVariant* operand) noexcept;
+
 /// \brief The class `unbounded_variant` describes a type-safe container
 ///        for single values of unbounded_variant copy and/or move constructible type.
 ///
@@ -946,18 +977,17 @@ private:
 /// \tparam Copyable Determines whether a contained object is copy constructible.
 /// \tparam Movable Determines whether a contained object is move constructible.
 /// \tparam Alignment Alignment of storage for a contained object.
-/// \tparam IsPmr Polymorphic Memory Resource (PMR) support.
+/// \tparam Pmr Type of Polymorphic Memory Resource (PMR). Use `void` to disable PMR support.
 ///
 template <std::size_t Footprint,
           bool        Copyable  = true,
           bool        Movable   = Copyable,
           std::size_t Alignment = alignof(std::max_align_t),
-          bool        IsPmr     = false>
-class unbounded_variant : detail::base_move<Footprint, Copyable, Movable, Alignment, IsPmr>
+          typename Pmr          = void>
+class unbounded_variant : detail::base_move<Pmr, Footprint, Copyable, Movable, Alignment>
 {
-    using IsPmrT     = std::integral_constant<bool, IsPmr>;
     using IsMovableT = std::integral_constant<bool, Movable>;
-    using base       = detail::base_move<Footprint, Copyable, Movable, Alignment, IsPmr>;
+    using base       = detail::base_move<Pmr, Footprint, Copyable, Movable, Alignment>;
 
 public:
     using base::reset;
@@ -968,16 +998,19 @@ public:
     ///
     /// In case of enabled PMR support, the default memory resource is used.
     ///
-    unbounded_variant() = default;
+    template <typename PmrAlias = Pmr, typename = detail::EnableIfNotPmrT<PmrAlias>>
+    unbounded_variant()
+    {
+    }
 
     /// \brief Constructs an empty `unbounded_variant` object with PMR support.
     ///
     /// \param mem_res Pointer to a memory resource to be used by the variant.
     ///
-    explicit unbounded_variant(pmr::memory_resource* const mem_res)
+    template <typename PmrAlias = Pmr, typename = detail::EnableIfPmrT<PmrAlias>>
+    explicit unbounded_variant(Pmr* const mem_res)
         : base{mem_res}
     {
-        static_assert(IsPmr, "Cannot construct non-PMR unbounded_variant with memory resource.");
     }
 
     /// \brief Constructs an `unbounded_variant` object with a copy of the content of `other`.
@@ -1003,13 +1036,15 @@ public:
     /// In case of enabled PMR support, the default memory resource is used.
     ///
     /// \tparam ValueType Type of the value to be stored.
-    ///                   Its size must be less than or equal to `Footprint` in case `IsPmr=false`.
+    ///                   Its size must be less than or equal to `Footprint` in case of PMR support.
     /// \param value Value to be stored.
     ///
     template <typename ValueType,
-              typename Tp = std::decay_t<ValueType>,
-              typename    = std::enable_if_t<!std::is_same<Tp, unbounded_variant>::value &&
-                                             !pf17::detail::is_in_place_type<ValueType>::value>>
+              typename Tp       = std::decay_t<ValueType>,
+              typename PmrAlias = Pmr,
+              typename          = detail::EnableIfNotPmrT<PmrAlias>,
+              typename          = std::enable_if_t<!std::is_same<Tp, unbounded_variant>::value &&
+                                                   !pf17::detail::is_in_place_type<ValueType>::value>>
     unbounded_variant(ValueType&& value)  // NOLINT(*-explicit-constructor)
     {
         create<Tp>(std::forward<ValueType>(value));
@@ -1026,11 +1061,12 @@ public:
     /// \param value Value to be stored.
     ///
     template <typename ValueType,
-              typename Tp     = std::decay_t<ValueType>,
-              bool IsPmrAlias = IsPmr,
-              typename        = std::enable_if_t<!std::is_same<Tp, unbounded_variant>::value && IsPmrAlias &&
-                                                 !pf17::detail::is_in_place_type<ValueType>::value>>
-    unbounded_variant(pmr::memory_resource* const mem_res, ValueType&& value)
+              typename Tp       = std::decay_t<ValueType>,
+              typename PmrAlias = Pmr,
+              typename          = detail::EnableIfPmrT<PmrAlias>,
+              typename          = std::enable_if_t<!std::is_same<Tp, unbounded_variant>::value &&
+                                                   !pf17::detail::is_in_place_type<ValueType>::value>>
+    unbounded_variant(Pmr* const mem_res, ValueType&& value)
         : base{mem_res}
     {
         create<Tp>(std::forward<ValueType>(value));
@@ -1048,7 +1084,11 @@ public:
     /// \tparam Args Types of arguments to be passed to the constructor of `ValueType`.
     /// \param args Arguments to be forwarded to the constructor of `ValueType`.
     ///
-    template <typename ValueType, typename... Args, typename Tp = std::decay_t<ValueType>>
+    template <typename ValueType,
+              typename... Args,
+              typename Tp       = std::decay_t<ValueType>,
+              typename PmrAlias = Pmr,
+              typename          = detail::EnableIfNotPmrT<PmrAlias>>
     explicit unbounded_variant(in_place_type_t<ValueType>, Args&&... args)
     {
         create<Tp>(std::forward<Args>(args)...);
@@ -1067,9 +1107,10 @@ public:
     ///
     template <typename ValueType,
               typename... Args,
-              bool IsPmrAlias = IsPmr,
-              typename Tp     = std::enable_if_t<IsPmrAlias, std::decay_t<ValueType>>>
-    explicit unbounded_variant(pmr::memory_resource* const mem_res, in_place_type_t<ValueType>, Args&&... args)
+              typename Tp       = std::decay_t<ValueType>,
+              typename PmrAlias = Pmr,
+              typename          = detail::EnableIfPmrT<PmrAlias>>
+    explicit unbounded_variant(Pmr* const mem_res, in_place_type_t<ValueType>, Args&&... args)
         : base{mem_res}
     {
         create<Tp>(std::forward<Args>(args)...);
@@ -1089,7 +1130,12 @@ public:
     /// \param list Initializer list to be forwarded to the constructor of `ValueType`.
     /// \param args Arguments to be forwarded to the constructor of `ValueType`.
     ///
-    template <typename ValueType, typename Up, typename... Args, typename Tp = std::decay_t<ValueType>>
+    template <typename ValueType,
+              typename Up,
+              typename... Args,
+              typename Tp       = std::decay_t<ValueType>,
+              typename PmrAlias = Pmr,
+              typename          = detail::EnableIfNotPmrT<PmrAlias>>
     explicit unbounded_variant(in_place_type_t<ValueType>, std::initializer_list<Up> list, Args&&... args)
     {
         create<Tp>(list, std::forward<Args>(args)...);
@@ -1111,9 +1157,10 @@ public:
     template <typename ValueType,
               typename Up,
               typename... Args,
-              bool IsPmrAlias = IsPmr,
-              typename Tp     = std::enable_if_t<IsPmrAlias, std::decay_t<ValueType>>>
-    explicit unbounded_variant(pmr::memory_resource* const mem_res,
+              typename Tp       = std::decay_t<ValueType>,
+              typename PmrAlias = Pmr,
+              typename          = detail::EnableIfPmrT<PmrAlias>>
+    explicit unbounded_variant(Pmr* const mem_res,
                                in_place_type_t<ValueType>,
                                std::initializer_list<Up> list,
                                Args&&... args)
@@ -1222,7 +1269,7 @@ public:
     /// and depending on which stage of swapping the failure happened
     /// it could affect (invalidate) either of `*this` or `rhs` variants.
     /// Use `valueless_by_exception()` method to check if a variant is in such failure state,
-    /// and `reset` (or `reset(pmr::memory_resource*)`) method to recover from it.
+    /// and `reset` (or `reset(Pmr*)`) method to recover from it.
     ///
     void swap(unbounded_variant& rhs) noexcept(Movable)
     {
@@ -1231,15 +1278,14 @@ public:
             return;
         }
 
-        swapVariants(IsPmrT{}, IsMovableT{}, rhs);
+        swapVariants(detail::IsPmr<Pmr>{}, IsMovableT{}, rhs);
     }
 
     /// \brief Gets current memory resource in use by the variant.
     ///
-    CETL_NODISCARD pmr::memory_resource* get_memory_resource() const noexcept
+    template <typename PmrAlias = Pmr, typename = detail::EnableIfPmrT<PmrAlias>>
+    CETL_NODISCARD Pmr* get_memory_resource() const noexcept
     {
-        static_assert(IsPmr, "Cannot get memory resource from non-PMR unbounded_variant.");
-
         return base::get_memory_resource();
     }
 
@@ -1247,10 +1293,9 @@ public:
     ///
     /// Useful to recover from the "valueless by exception" state (see `swap` method).
     ///
-    void reset(pmr::memory_resource* const mem_res) noexcept
+    template <typename PmrAlias = Pmr, typename = detail::EnableIfPmrT<PmrAlias>>
+    void reset(Pmr* const mem_res) noexcept
     {
-        static_assert(IsPmr, "Cannot reset memory resource to non-PMR unbounded_variant.");
-
         base::reset();
         base::set_memory_resource(mem_res);
     }

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -89,7 +89,8 @@ struct base_storage<Footprint, false /*IsPmr*/, Alignment>
     ///
     CETL_NODISCARD void* alloc_new_raw_storage(const std::size_t size_bytes) noexcept
     {
-        CETL_DEBUG_ASSERT((0UL < size_bytes) && (size_bytes <= Footprint), "");
+        CETL_DEBUG_ASSERT(0UL < size_bytes, "");
+        CETL_DEBUG_ASSERT(size_bytes <= Footprint, "");
         CETL_DEBUG_ASSERT(0UL == value_size_, "This object is expected to be a brand new one.");
 
         // We need to store (presumably) allocated size b/c this is important

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -1094,7 +1094,6 @@ public:
     Tp* emplace(Args&&... args)
     {
         reset();
-
         return create<Tp>(std::forward<Args>(args)...);
     }
 
@@ -1110,7 +1109,6 @@ public:
     Tp* emplace(std::initializer_list<Up> list, Args&&... args)
     {
         reset();
-
         return create<Tp>(list, std::forward<Args>(args)...);
     }
 

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -1096,7 +1096,7 @@ public:
     /// \brief Swaps the content of `*this` with the content of `rhs`
     /// using either move (if available) or copy semantics.
     ///
-    void swap(unbounded_variant& rhs) noexcept
+    void swap(unbounded_variant& rhs) noexcept(Movable)
     {
         if (this == &rhs)
         {
@@ -1154,7 +1154,7 @@ private:
         return unbounded_variant(get_memory_resource(), std::forward<ValueType>(value));
     }
 
-    void swapVariants(std::false_type /*IsPmr*/, std::false_type /*Movable*/, unbounded_variant& rhs) noexcept
+    void swapVariants(std::false_type /*IsPmr*/, std::false_type /*Movable*/, unbounded_variant& rhs)
     {
         if (has_value())
         {
@@ -1177,28 +1177,7 @@ private:
         }
     }
 
-    void swapVariants(std::false_type /*IsPmr*/, std::true_type /*Movable*/, unbounded_variant& rhs) noexcept
-    {
-        if (has_value())
-        {
-            if (rhs.has_value())
-            {
-                unbounded_variant tmp{std::move(rhs)};
-                static_cast<base&>(rhs)   = std::move(*this);
-                static_cast<base&>(*this) = std::move(tmp);
-            }
-            else
-            {
-                static_cast<base&>(rhs) = std::move(*this);
-            }
-        }
-        else if (rhs.has_value())
-        {
-            static_cast<base&>(*this) = std::move(rhs);
-        }
-    }
-
-    void swapVariants(std::true_type /*IsPmr*/, std::false_type /*Movable*/, unbounded_variant& rhs) noexcept
+    void swapVariants(std::true_type /*IsPmr*/, std::false_type /*Movable*/, unbounded_variant& rhs)
     {
         if (has_value())
         {
@@ -1227,6 +1206,27 @@ private:
         {
             auto* const tmp_mr = base::set_memory_resource(rhs.get_memory_resource());
             rhs.set_memory_resource(tmp_mr);
+        }
+    }
+
+    void swapVariants(std::false_type /*IsPmr*/, std::true_type /*Movable*/, unbounded_variant& rhs) noexcept
+    {
+        if (has_value())
+        {
+            if (rhs.has_value())
+            {
+                unbounded_variant tmp{std::move(rhs)};
+                static_cast<base&>(rhs)   = std::move(*this);
+                static_cast<base&>(*this) = std::move(tmp);
+            }
+            else
+            {
+                static_cast<base&>(rhs) = std::move(*this);
+            }
+        }
+        else if (rhs.has_value())
+        {
+            static_cast<base&>(*this) = std::move(rhs);
         }
     }
 

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -525,7 +525,7 @@ struct base_access : base_storage<Pmr, Footprint, Alignment>
         return (base::get_value_size() > 0UL) && (nullptr != value_destroyer_);
     }
 
-    /// True if the variant is valueless b/c of an exception.
+    /// True if the variant is valueless b/c of an exception or OOM.
     ///
     /// Use `reset` method (or try assign a new value) to recover from this state.
     ///
@@ -1269,7 +1269,7 @@ public:
     /// and depending on which stage of swapping the failure happened
     /// it could affect (invalidate) either of `*this` or `rhs` variants.
     /// Use `valueless_by_exception()` method to check if a variant is in such failure state,
-    /// and `reset` (or `reset(Pmr*)`) method to recover from it.
+    /// and `reset` (or `reset(Pmr*)`) method (or assign a new value) to recover from it.
     ///
     void swap(unbounded_variant& rhs) noexcept(Movable)
     {

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -502,6 +502,8 @@ struct base_access : base_storage<Footprint, IsPmr, Alignment>
     template <typename Tp>
     void make_handlers() noexcept
     {
+        static_assert(sizeof(Tp) <= Footprint || IsPmr, "Enlarge the footprint");
+
         CETL_DEBUG_ASSERT(nullptr == value_destroyer_, "Expected to be empty before making handlers.");
         CETL_DEBUG_ASSERT(nullptr == value_converter_, "");
         CETL_DEBUG_ASSERT(nullptr == value_const_converter_, "");

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -101,10 +101,17 @@ private:
 template <std::size_t Alignment>
 struct base_storage<0UL /*Footprint*/, true /*IsPmr*/, Alignment>
 {
-    explicit base_storage(pmr::memory_resource* const mem_res = nullptr)
+    base_storage()
         : allocated_size_{0}
         , allocated_buffer_{nullptr}
-        , mem_res_{nullptr != mem_res ? mem_res : cetl::pmr::get_default_resource()}
+        , mem_res_{cetl::pmr::get_default_resource()}
+    {
+    }
+
+    explicit base_storage(pmr::memory_resource* const mem_res)
+        : allocated_size_{0}
+        , allocated_buffer_{nullptr}
+        , mem_res_{mem_res}
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
     }
@@ -196,10 +203,17 @@ private:
 template <std::size_t Footprint, std::size_t Alignment>
 struct base_storage<Footprint, true /*IsPmr*/, Alignment>
 {
-    explicit base_storage(pmr::memory_resource* const mem_res = nullptr)
+    base_storage()
         : allocated_size_{0}
         , allocated_buffer_{nullptr}
-        , mem_res_{nullptr != mem_res ? mem_res : cetl::pmr::get_default_resource()}
+        , mem_res_{cetl::pmr::get_default_resource()}
+    {
+    }
+
+    explicit base_storage(pmr::memory_resource* const mem_res)
+        : allocated_size_{0}
+        , allocated_buffer_{nullptr}
+        , mem_res_{mem_res}
     {
         CETL_DEBUG_ASSERT(nullptr != mem_res_, "");
     }
@@ -299,7 +313,7 @@ private:
 template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
 struct base_access : base_storage<Footprint, IsPmr, Alignment>
 {
-    constexpr base_access() = default;
+    base_access() = default;
 
     explicit base_access(pmr::memory_resource* const mem_res)
         : base{mem_res}
@@ -444,7 +458,7 @@ template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
 struct base_handlers<Footprint, false /*Copyable*/, false /*Moveable*/, Alignment, IsPmr>
     : base_access<Footprint, Alignment, IsPmr>
 {
-    constexpr base_handlers() = default;
+    base_handlers() = default;
 
     explicit base_handlers(pmr::memory_resource* const mem_res)
         : base{mem_res}
@@ -459,7 +473,7 @@ template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
 struct base_handlers<Footprint, true /*Copyable*/, false /*Moveable*/, Alignment, IsPmr>
     : base_access<Footprint, Alignment, IsPmr>
 {
-    constexpr base_handlers() = default;
+    base_handlers() = default;
 
     explicit base_handlers(pmr::memory_resource* const mem_res)
         : base{mem_res}
@@ -502,7 +516,7 @@ template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
 struct base_handlers<Footprint, false /*Copyable*/, true /*Moveable*/, Alignment, IsPmr>
     : base_access<Footprint, Alignment, IsPmr>
 {
-    constexpr base_handlers() = default;
+    base_handlers() = default;
 
     explicit base_handlers(pmr::memory_resource* const mem_res)
         : base{mem_res}
@@ -545,7 +559,7 @@ template <std::size_t Footprint, std::size_t Alignment, bool IsPmr>
 struct base_handlers<Footprint, true /*Copyable*/, true /*Moveable*/, Alignment, IsPmr>
     : base_access<Footprint, Alignment, IsPmr>
 {
-    constexpr base_handlers() = default;
+    base_handlers() = default;
 
     explicit base_handlers(pmr::memory_resource* const mem_res)
         : base{mem_res}
@@ -604,7 +618,7 @@ template <std::size_t Footprint, bool Moveable, std::size_t Alignment, bool IsPm
 struct base_copy<Footprint, false /*Copyable*/, Moveable, Alignment, IsPmr>
     : base_handlers<Footprint, false /*Copyable*/, Moveable, Alignment, IsPmr>
 {
-    constexpr base_copy()                  = default;
+    base_copy()                            = default;
     base_copy(const base_copy&)            = delete;
     base_copy& operator=(const base_copy&) = delete;
 
@@ -622,9 +636,10 @@ template <std::size_t Footprint, bool Moveable, std::size_t Alignment, bool IsPm
 struct base_copy<Footprint, true /*Copyable*/, Moveable, Alignment, IsPmr>
     : base_handlers<Footprint, true /*Copyable*/, Moveable, Alignment, IsPmr>
 {
-    constexpr base_copy() = default;
+    base_copy() = default;
 
     base_copy(const base_copy& other)
+        : base{}
     {
         copy_from(other);
     }
@@ -684,7 +699,7 @@ template <std::size_t Footprint, bool Copyable, std::size_t Alignment, bool IsPm
 struct base_move<Footprint, Copyable, false /*Movable*/, Alignment, IsPmr>
     : base_copy<Footprint, Copyable, false /*Movable*/, Alignment, IsPmr>
 {
-    constexpr base_move()           = default;
+    base_move()                     = default;
     base_move(const base_move&)     = default;
     base_move(base_move&&) noexcept = delete;
 
@@ -705,11 +720,12 @@ template <std::size_t Footprint, bool Copyable, std::size_t Alignment, bool IsPm
 struct base_move<Footprint, Copyable, true /*Movable*/, Alignment, IsPmr>
     : base_copy<Footprint, Copyable, true /*Movable*/, Alignment, IsPmr>
 {
-    constexpr base_move()                  = default;
+    base_move()                            = default;
     base_move(const base_move&)            = default;
     base_move& operator=(const base_move&) = default;
 
     base_move(base_move&& other) noexcept
+        : base{}
     {
         move_from(other);
     }
@@ -791,7 +807,7 @@ class unbounded_variant : detail::base_move<Footprint, Copyable, Movable, Alignm
 public:
     /// \brief Constructs an empty `unbounded_variant` object.
     ///
-    constexpr unbounded_variant() = default;
+    unbounded_variant() = default;
 
     explicit unbounded_variant(pmr::memory_resource* const mem_res)
         : base{mem_res}

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -1132,11 +1132,12 @@ public:
         return base::get_memory_resource();
     }
 
-    pmr::memory_resource* set_memory_resource(pmr::memory_resource* const mem_res) noexcept
+    void reset(pmr::memory_resource* const mem_res) noexcept
     {
-        static_assert(IsPmr, "Cannot set memory resource to non-PMR unbounded_variant.");
+        static_assert(IsPmr, "Cannot reset memory resource to non-PMR unbounded_variant.");
 
-        return base::set_memory_resource(mem_res);
+        base::reset();
+        base::set_memory_resource(mem_res);
     }
 
 private:


### PR DESCRIPTION
- Added `IsPmr` support to `cetl::unbounded_variant`.
- Added new `cetl::pmr::function` (aka `std::function` but with PMR instead of c++ heap).
- Added new `cetl::pmr::InterfacePtr` and its `InterfaceFactrory::make_unique`
  - based on `std::unique_ptr` but with custom PMR-based allocator and deleter
  - allows to hide implementation (aka Concrete) type from result InterfacePtr
  - allows to delete destructor from an interface type