### PR TITLE
Minor improvement of the `cetlvast::TrackingMemoryResource`

### DIFF
--- a/cetlvast/include/cetlvast/memory_resource_mock.hpp
+++ b/cetlvast/include/cetlvast/memory_resource_mock.hpp
@@ -17,15 +17,10 @@ namespace cetlvast
 class MemoryResourceMock : public cetl::pmr::memory_resource
 {
 public:
-    cetl::pmr::memory_resource* resource() noexcept
-    {
-        return this;
-    }
-
     MOCK_METHOD(void*, do_allocate, (std::size_t, std::size_t), (override));
     MOCK_METHOD(void, do_deallocate, (void*, std::size_t, std::size_t));
     // NOLINTNEXTLINE(bugprone-exception-escape)
-    MOCK_METHOD(bool, do_is_equal, (const memory_resource&), (const, noexcept, override));
+    MOCK_METHOD(bool, do_is_equal, (const cetl::pmr::memory_resource&), (const, noexcept, override));
 
 #if (__cplusplus < CETL_CPP_STANDARD_17)
     // NOLINTNEXTLINE(bugprone-exception-escape)
@@ -45,7 +40,7 @@ public:
             .WillRepeatedly([&mr](void* p, std::size_t size_bytes, std::size_t alignment) {
                 mr.deallocate(p, size_bytes, alignment);
             });
-        EXPECT_CALL(*this, do_is_equal(_)).WillRepeatedly([&mr](const memory_resource& rhs) {
+        EXPECT_CALL(*this, do_is_equal(_)).WillRepeatedly([&mr](const cetl::pmr::memory_resource& rhs) {
             return mr.is_equal(rhs);
         });
 

--- a/cetlvast/include/cetlvast/memory_resource_mock.hpp
+++ b/cetlvast/include/cetlvast/memory_resource_mock.hpp
@@ -17,6 +17,11 @@ namespace cetlvast
 class MemoryResourceMock : public cetl::pmr::memory_resource
 {
 public:
+    cetl::pmr::memory_resource* resource() noexcept
+    {
+        return this;
+    }
+
     MOCK_METHOD(void*, do_allocate, (std::size_t, std::size_t), (override));
     MOCK_METHOD(void, do_deallocate, (void*, std::size_t, std::size_t));
     // NOLINTNEXTLINE(bugprone-exception-escape)

--- a/cetlvast/include/cetlvast/tracking_memory_resource.hpp
+++ b/cetlvast/include/cetlvast/tracking_memory_resource.hpp
@@ -7,8 +7,10 @@
 #define CETLVAST_TRACKING_MEMORY_RESOURCE_HPP_INCLUDED
 
 #include "cetl/pf17/cetlpf.hpp"
-#include "cetl/pmr/memory.hpp"
 
+#include <algorithm>
+#include <cstddef>
+#include <ios>
 #include <ostream>
 #include <vector>
 
@@ -30,9 +32,10 @@ public:
     };
 
     // NOLINTBEGIN
-    std::vector<Allocation> allocations{};
-    std::size_t             total_allocated_bytes   = 0;
-    std::size_t             total_deallocated_bytes = 0;
+    std::vector<Allocation>     allocations{};
+    std::size_t                 total_allocated_bytes   = 0;
+    std::size_t                 total_deallocated_bytes = 0;
+    cetl::pmr::memory_resource* memory_{cetl::pmr::get_default_resource()};
     // NOLINTEND
 
 private:
@@ -48,7 +51,7 @@ private:
             return nullptr;
         }
 
-        auto ptr = std::malloc(size_bytes);
+        void* ptr = memory_->allocate(size_bytes, alignment);
 
         total_allocated_bytes += size_bytes;
         allocations.push_back({size_bytes, ptr});
@@ -56,7 +59,7 @@ private:
         return ptr;
     }
 
-    void do_deallocate(void* ptr, std::size_t size_bytes, std::size_t) override
+    void do_deallocate(void* ptr, std::size_t size_bytes, std::size_t alignment) override
     {
         auto prev_alloc = std::find_if(allocations.cbegin(), allocations.cend(), [ptr](const auto& alloc) {
             return alloc.pointer == ptr;
@@ -67,22 +70,25 @@ private:
         }
         total_deallocated_bytes += size_bytes;
 
-        std::free(ptr);
+        memory_->deallocate(ptr, size_bytes, alignment);
     }
 
 #if (__cplusplus < CETL_CPP_STANDARD_17)
 
-    void* do_reallocate(void* ptr, std::size_t old_size_bytes, std::size_t new_size_bytes, std::size_t) override
+    void* do_reallocate(void*       ptr,
+                        std::size_t old_size_bytes,
+                        std::size_t new_size_bytes,
+                        std::size_t alignment) override
     {
         total_allocated_bytes -= old_size_bytes;
         total_allocated_bytes += new_size_bytes;
 
-        return std::realloc(ptr, new_size_bytes);
+        return memory_->reallocate(ptr, old_size_bytes, new_size_bytes, alignment);
     }
 
 #endif
 
-    bool do_is_equal(const memory_resource& rhs) const noexcept override
+    bool do_is_equal(const cetl::pmr::memory_resource& rhs) const noexcept override
     {
         return (&rhs == this);
     }


### PR DESCRIPTION
It is now based on `cetl::pmr::get_default_resource()` (instead of `std::malloc` etc).