### PR TITLE
Sshirokov/benchmark

### DIFF
--- a/cetlvast/CMakeLists.txt
+++ b/cetlvast/CMakeLists.txt
@@ -162,6 +162,7 @@ add_project_library(
 )
 
 find_package(clangformat)
+find_package(benchmark)
 
 if(clangformat_FOUND)
     # define a dry-run version that we always run.
@@ -198,7 +199,9 @@ endif()
 add_subdirectory(${CMAKE_SOURCE_DIR}/suites/unittest)
 add_subdirectory(${CMAKE_SOURCE_DIR}/suites/docs)
 add_subdirectory(${CMAKE_SOURCE_DIR}/suites/compile)
-
+if(benchmark_FOUND)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/suites/benchmark)
+endif()
 # +---------------------------------------------------------------------------+
 # | BUILD TARGET ALIASES
 # +---------------------------------------------------------------------------+

--- a/cetlvast/suites/benchmark/CMakeLists.txt
+++ b/cetlvast/suites/benchmark/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT
+#
+
+cmake_minimum_required(VERSION 3.22.0)
+
+project(cetlvast_benchmark CXX)
+
+find_package(benchmark REQUIRED)
+
+file(GLOB_RECURSE TEST_SOURCES
+        LIST_DIRECTORIES false
+        CONFIGURE_DEPENDS
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+        benchmark_*.cpp **/benchmark_*.cpp
+)
+
+set(ALL_TESTS_BUILD "")
+
+foreach(TEST_SOURCE ${TEST_SOURCES})
+
+    cmake_path(GET TEST_SOURCE STEM TEST_NAME)
+
+    add_executable(${TEST_NAME} ${TEST_SOURCE})
+    target_link_libraries(${TEST_NAME} cetl benchmark::benchmark)
+
+    list(APPEND ALL_TESTS_BUILD ${TEST_NAME})
+
+endforeach()
+
+add_custom_target(
+        build_benchmarks
+        DEPENDS
+        ${ALL_TESTS_BUILD}
+)

--- a/cetlvast/suites/benchmark/pmr/benchmark_pmr_function.cpp
+++ b/cetlvast/suites/benchmark/pmr/benchmark_pmr_function.cpp
@@ -1,0 +1,69 @@
+#include <cetl/pmr/function.hpp>
+
+#include <benchmark/benchmark.h>
+
+namespace
+{
+
+void BM_CetlFn_call(benchmark::State& state)
+{
+    cetl::pmr::function<int64_t(int64_t), 16> fn = [](int64_t i) {
+        benchmark::DoNotOptimize(i);
+        return i;
+    };
+    for (auto _ : state)
+    {
+        int64_t    res = 0;
+        const auto lim = state.range();
+        for (int i = 0; i < lim; ++i)
+        {
+            res += fn(i);
+        }
+        benchmark::DoNotOptimize(res);
+    }
+}
+
+void BM_StdFn_call(benchmark::State& state)
+{
+    std::function<int64_t(int64_t)> fn = [](int64_t i) {
+        benchmark::DoNotOptimize(i);
+        return i;
+    };
+    for (auto _ : state)
+    {
+        int64_t    res = 0;
+        const auto lim = state.range();
+        for (int i = 0; i < lim; ++i)
+        {
+            res += fn(i);
+        }
+        benchmark::DoNotOptimize(res);
+    }
+}
+
+void BM_Lambda_call(benchmark::State& state)
+{
+    auto fn = [](int64_t i) {
+        benchmark::DoNotOptimize(i);
+        return i;
+    };
+    for (auto _ : state)
+    {
+        int64_t    res = 0;
+        const auto lim = state.range();
+        for (int i = 0; i < lim; ++i)
+        {
+            res += fn(i);
+        }
+        benchmark::DoNotOptimize(res);
+    }
+    (void) fn;
+}
+
+}  // namespace
+
+BENCHMARK(BM_CetlFn_call)->Arg(1000);
+BENCHMARK(BM_StdFn_call)->Arg(1000);
+BENCHMARK(BM_Lambda_call)->Arg(1000);
+
+BENCHMARK_MAIN();

--- a/include/cetl/unbounded_variant.hpp
+++ b/include/cetl/unbounded_variant.hpp
@@ -657,7 +657,9 @@ struct base_access : base_storage<Pmr, Footprint, Alignment>
         // Non-PMR storage can store any value as long as it fits into the footprint.
         static_assert((Footprint > 0) || IsPmr<Pmr>::value, "Make non-zero footprint, or enable PMR support.");
 
-        if (has_value())
+        // `has_value()` already checks for `value_destroyer_` not being `nullptr`,
+        // but clang-tidy doesn't see it, so we get false positive here - hence the explicit double check.
+        if (has_value() && (nullptr != value_destroyer_))
         {
             value_destroyer_(base::get_raw_storage());
         }


### PR DESCRIPTION
- Fix clang-tidy false positive.
- Added new "benchmark" suite.
- The suite now has benchmark of the `cetl::function` (comparing with `std::function` and pure lambda):
```
2024-12-03T12:04:03+02:00
Running /home/sergei/Develop/git/OpenCyphal/CETL/cetlvast/cmake-build-release/suites/benchmark/benchmark_pmr_function
Run on (16 X 4791.28 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.73, 1.78, 2.14
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
BM_CetlFn_call/1000       1030 ns         1030 ns       672510
BM_StdFn_call/1000        1026 ns         1026 ns       690998
BM_Lambda_call/1000        206 ns          206 ns      3390901

Process finished with exit code 0
```