### PR TITLE
Working around GCC7 bug handling temporary template parameters

### DIFF
--- a/cetlvast/CMakePresets.json
+++ b/cetlvast/CMakePresets.json
@@ -295,24 +295,6 @@
             ]
         },
         {
-            "name": "configure-gcc7-native-cpp-23-online",
-            "inherits": [
-                "configure-common",
-                "configure-toolchain-gcc7-native",
-                "configure-standard-cpp-23",
-                "configure-update-online"
-            ]
-        },
-        {
-            "name": "configure-gcc7-native-cpp-23-offline",
-            "inherits": [
-                "configure-common",
-                "configure-toolchain-gcc7-native",
-                "configure-standard-cpp-23",
-                "configure-update-offline"
-            ]
-        },
-        {
             "name": "configure-clang-native-cpp-14-online",
             "inherits": [
                 "configure-common",
@@ -622,26 +604,6 @@
             ]
         },
         {
-            "name": "build-Release-gcc7-native-cpp-23-online",
-            "configurePreset": "configure-gcc7-native-cpp-23-online",
-            "configuration": "Release",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
-            "name": "build-Release-gcc7-native-cpp-23-offline",
-            "configurePreset": "configure-gcc7-native-cpp-23-offline",
-            "configuration": "Release",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
             "name": "build-Release-clang-native-cpp-14-online",
             "configurePreset": "configure-clang-native-cpp-14-online",
             "configuration": "Release",
@@ -894,26 +856,6 @@
         {
             "name": "build-ReleaseEP-gcc7-native-cpp-14-offline",
             "configurePreset": "configure-gcc7-native-cpp-14-offline",
-            "configuration": "ReleaseEP",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
-            "name": "build-ReleaseEP-gcc7-native-cpp-23-online",
-            "configurePreset": "configure-gcc7-native-cpp-23-online",
-            "configuration": "ReleaseEP",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
-            "name": "build-ReleaseEP-gcc7-native-cpp-23-offline",
-            "configurePreset": "configure-gcc7-native-cpp-23-offline",
             "configuration": "ReleaseEP",
             "targets": [
                 "build",
@@ -1182,26 +1124,6 @@
             ]
         },
         {
-            "name": "build-Debug-gcc7-native-cpp-23-online",
-            "configurePreset": "configure-gcc7-native-cpp-23-online",
-            "configuration": "Debug",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
-            "name": "build-Debug-gcc7-native-cpp-23-offline",
-            "configurePreset": "configure-gcc7-native-cpp-23-offline",
-            "configuration": "Debug",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
             "name": "build-Debug-clang-native-cpp-14-online",
             "configurePreset": "configure-clang-native-cpp-14-online",
             "configuration": "Debug",
@@ -1454,26 +1376,6 @@
         {
             "name": "build-DebugEP-gcc7-native-cpp-14-offline",
             "configurePreset": "configure-gcc7-native-cpp-14-offline",
-            "configuration": "DebugEP",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
-            "name": "build-DebugEP-gcc7-native-cpp-23-online",
-            "configurePreset": "configure-gcc7-native-cpp-23-online",
-            "configuration": "DebugEP",
-            "targets": [
-                "build",
-                "run_unittests",
-                "run_examples"
-            ]
-        },
-        {
-            "name": "build-DebugEP-gcc7-native-cpp-23-offline",
-            "configurePreset": "configure-gcc7-native-cpp-23-offline",
             "configuration": "DebugEP",
             "targets": [
                 "build",
@@ -1819,36 +1721,6 @@
         {
             "name": "build-Coverage-gcc7-native-cpp-14-offline",
             "configurePreset": "configure-gcc7-native-cpp-14-offline",
-            "configuration": "Coverage",
-            "targets": [
-                "build",
-                "run_unittests",
-                "gcovr_html_report_for_unittest",
-                "gcovr_sonarqube_report_for_unittest",
-                "run_examples",
-                "gcovr_html_report_for_examples",
-                "gcovr_sonarqube_report_for_examples",
-                "sonar-cloud-scan-OpenCyphal_CETL"
-            ]
-        },
-        {
-            "name": "build-Coverage-gcc7-native-cpp-23-online",
-            "configurePreset": "configure-gcc7-native-cpp-23-online",
-            "configuration": "Coverage",
-            "targets": [
-                "build",
-                "run_unittests",
-                "gcovr_html_report_for_unittest",
-                "gcovr_sonarqube_report_for_unittest",
-                "run_examples",
-                "gcovr_html_report_for_examples",
-                "gcovr_sonarqube_report_for_examples",
-                "sonar-cloud-scan-OpenCyphal_CETL"
-            ]
-        },
-        {
-            "name": "build-Coverage-gcc7-native-cpp-23-offline",
-            "configurePreset": "configure-gcc7-native-cpp-23-offline",
             "configuration": "Coverage",
             "targets": [
                 "build",
@@ -2530,60 +2402,6 @@
             ]
         },
         {
-            "name": "workflow-gcc7-native-cpp-23-online",
-            "displayName": "gcc7 native cpp 23 online",
-            "description": "autogenerated workflow",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "configure-gcc7-native-cpp-23-online"
-                },
-                {
-                    "type": "build",
-                    "name": "build-Release-gcc7-native-cpp-23-online"
-                },
-                {
-                    "type": "build",
-                    "name": "build-ReleaseEP-gcc7-native-cpp-23-online"
-                },
-                {
-                    "type": "build",
-                    "name": "build-Debug-gcc7-native-cpp-23-online"
-                },
-                {
-                    "type": "build",
-                    "name": "build-DebugEP-gcc7-native-cpp-23-online"
-                }
-            ]
-        },
-        {
-            "name": "workflow-gcc7-native-cpp-23-offline",
-            "displayName": "gcc7 native cpp 23 offline",
-            "description": "autogenerated workflow",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "configure-gcc7-native-cpp-23-offline"
-                },
-                {
-                    "type": "build",
-                    "name": "build-Release-gcc7-native-cpp-23-offline"
-                },
-                {
-                    "type": "build",
-                    "name": "build-ReleaseEP-gcc7-native-cpp-23-offline"
-                },
-                {
-                    "type": "build",
-                    "name": "build-Debug-gcc7-native-cpp-23-offline"
-                },
-                {
-                    "type": "build",
-                    "name": "build-DebugEP-gcc7-native-cpp-23-offline"
-                }
-            ]
-        },
-        {
             "name": "workflow-clang-native-cpp-14-online",
             "displayName": "clang native cpp 14 online",
             "description": "autogenerated workflow",
@@ -2876,7 +2694,8 @@
                             "toolchain": "gcc7-native",
                             "standard": [
                                 "cpp-17",
-                                "cpp-20"
+                                "cpp-20",
+                                "cpp-23"
                             ]
                         }
                     ],
@@ -2931,7 +2750,8 @@
                             "toolchain": "gcc7-native",
                             "standard": [
                                 "cpp-17",
-                                "cpp-20"
+                                "cpp-20",
+                                "cpp-23"
                             ]
                         }
                     ],
@@ -2980,7 +2800,8 @@
                             "toolchain": "gcc7-native",
                             "standard": [
                                 "cpp-17",
-                                "cpp-20"
+                                "cpp-20",
+                                "cpp-23"
                             ]
                         },
                         {

--- a/cetlvast/CMakePresetsVendorTemplate.json
+++ b/cetlvast/CMakePresetsVendorTemplate.json
@@ -70,7 +70,7 @@
                     "exclude": [
                         {
                             "toolchain": "gcc7-native",
-                            "standard": ["cpp-17", "cpp-20"]
+                            "standard": ["cpp-17", "cpp-20", "cpp-23"]
                         }
                     ],
                     "shape": {
@@ -103,7 +103,7 @@
                     "exclude": [
                         {
                             "toolchain": "gcc7-native",
-                            "standard": ["cpp-17", "cpp-20"]
+                            "standard": ["cpp-17", "cpp-20", "cpp-23"]
                         }
                     ],
                     "shape": {
@@ -127,7 +127,7 @@
                     "exclude": [
                         {
                             "toolchain": "gcc7-native",
-                            "standard": ["cpp-17", "cpp-20"]
+                            "standard": ["cpp-17", "cpp-20", "cpp-23"]
                         },
                         {
                             "configuration": "Coverage"

--- a/cetlvast/suites/unittest/test_pf17_variant_ctor_4.cpp
+++ b/cetlvast/suites/unittest/test_pf17_variant_ctor_4.cpp
@@ -42,16 +42,6 @@ TYPED_TEST(test_smf_policy_combinations, ctor_4)
     EXPECT_EQ(2, V(tag).index());
     EXPECT_EQ(3, V(monostate{}).index());
     static_assert(!std::is_constructible<V, double>::value, "");  // Ambiguity!
-
-    static_assert(1 == variant<int, bool>(true).index(), "");
-
-    // Example from cppreference
-    variant<float, long, double> v4 = 0;
-    EXPECT_EQ(0, get<long>(v4));
-
-    // Example from Scott
-    EXPECT_EQ(1, (variant<std::string, void const*>("abc").index()));
-    EXPECT_EQ(0, (variant<std::string, void*>("abc").index()));
 }
 
 static_assert(cetl::pf17::variant<int, void*, double>(123).index() == 0, "");

--- a/cetlvast/suites/unittest/test_pf17_variant_other.cpp
+++ b/cetlvast/suites/unittest/test_pf17_variant_other.cpp
@@ -247,7 +247,7 @@ static_assert(best_converting_ctor_index_v<std::int32_t, C, B> == bad, "");
 static_assert(best_converting_ctor_index_v<float, std::int32_t, float, double, bool> == 1, "");
 static_assert(best_converting_ctor_index_v<double, std::int32_t, float, double, bool> == 2, "");
 static_assert(best_converting_ctor_index_v<float, std::int32_t, long double, double, bool> == 2, "");
-static_assert(best_converting_ctor_index_v<char, float, double, bool> == bad, "");  // not unique
+static_assert(best_converting_ctor_index_v<signed char, float, double, bool> == bad, "");  // not unique
 
 static_assert(best_converting_ctor_index_v<int, int, bool> == 0, "");
 static_assert(best_converting_ctor_index_v<bool, int, bool> == 1, "");
@@ -291,7 +291,7 @@ static_assert(best_converting_assignment_index_v<double, C, B> == 0, "");
 static_assert(best_converting_assignment_index_v<float, std::int32_t, float, double, bool> == 1, "");
 static_assert(best_converting_assignment_index_v<double, std::int32_t, float, double, bool> == 2, "");
 static_assert(best_converting_assignment_index_v<float, std::int32_t, long double, double, bool> == 2, "");
-static_assert(best_converting_assignment_index_v<char, float, double, bool> == bad, "");  // not unique
+static_assert(best_converting_assignment_index_v<signed char, float, double, bool> == bad, "");  // not unique
 
 static_assert(best_converting_assignment_index_v<int, int, bool> == 0, "");
 static_assert(best_converting_assignment_index_v<bool, int, bool> == 1, "");
@@ -321,6 +321,26 @@ static_assert(0 == test_a(true, 123), "");
 static_assert(1 == test_a(true, 'a'), "");
 
 }  // namespace test_constexpr
+
+// --------------------------------------------------------------------------------------------
+
+TEST(test_variant, various_examples)
+{
+    using cetl::pf17::variant;
+    using cetl::pf17::get;
+
+    static_assert(1 == variant<int, bool>(true).index(), "");
+
+    // Example from cppreference
+    variant<float, long, double> v4 = 0;
+    EXPECT_EQ(0, get<long>(v4));
+
+    // Example from Scott
+    const std::size_t i0 = variant<std::string, void const*>("abc").index();
+    EXPECT_EQ(1, i0);
+    const std::size_t i1 = variant<std::string, void*>("abc").index();
+    EXPECT_EQ(0, i1);
+}
 
 // --------------------------------------------------------------------------------------------
 

--- a/cetlvast/suites/unittest/test_type_traits_ext.cpp
+++ b/cetlvast/suites/unittest/test_type_traits_ext.cpp
@@ -112,10 +112,10 @@ struct foo
 static_assert(best_conversion_index_v<universal_predicate, char, foo, int> == 1, "");
 static_assert(best_conversion_index_v<universal_predicate, char, foo> == 0, "");
 
-static_assert(best_conversion_index_v<partial<is_convertible_without_narrowing, char>::template type, char, foo, int> ==
+static_assert(best_conversion_index_v<partial<is_convertible_without_narrowing, signed char>::template type, signed char, foo, int> ==
                   1,
               "");
-static_assert(best_conversion_index_v<partial<is_convertible_without_narrowing, char>::template type, char, foo> == bad,
+static_assert(best_conversion_index_v<partial<is_convertible_without_narrowing, signed char>::template type, signed char, foo> == bad,
               "");
 static_assert(best_conversion_index_v<partial<is_convertible_without_narrowing, bool>::template type, bool, foo> == 0,
               "");


### PR DESCRIPTION
- fixes issue/151
- a couple more instances for issues/120
- removing some invalid C++23 cmake presets
- removing gcc7 ifdef around variant constexpr

This last one is a mystery. It appears the GCC7 constexpr bug was being caused by something else that has since been fixed as we've worked around better understood GCC7 bugs.