### PR TITLE
Fix for #187

### DIFF
--- a/include/cetl/variable_length_array.hpp
+++ b/include/cetl/variable_length_array.hpp
@@ -845,6 +845,7 @@ protected:
             }
             capacity_ = rhs.capacity_;
             size_     = rhs.size_;
+            fast_deallocate(rhs.data_, rhs.size_, rhs.capacity_, rhs.alloc_);
         }
         rhs.size_     = 0;
         rhs.capacity_ = 0;


### PR DESCRIPTION
`VariableLengthArrayBase` move construction with allocator, when `is_pocma_or_is_always_equal<Alloc>` is `false_type` and `this->alloc_ != rhs.alloc_`, will deallocate `rhs.data_` prior to setting `rhs.data_ = nullptr`.